### PR TITLE
44/WAKU2-PRIVATE-SETTLEMENT: RAW RFC

### DIFF
--- a/standards/application/private-settlement.md
+++ b/standards/application/private-settlement.md
@@ -1,0 +1,1 @@
+Removed


### PR DESCRIPTION
By: staheri14
Reference pull request: https://github.com/vacp2p/rfc/pull/540

Raw RFC for private settelement.

Some of the rationales behind the design choices are provided as inline comments (in the MD file), please read them through.

As a general note, we may want to simplify the UTXO usage, but I tried to first convey how UTXOs are originally used in other designs (so that we can use the current existing circom circuits) . Later we can revise and make it simpler if need be.
The main reason for using UTXOs is to allow custom value tokens (this is how it is done in Nova). I have already explained my reasoning in the RFC, copying them again here:
Custom token values have multiple benefits in the store protocol: 1) allow service providers to have their own pricing strategy, 2) it also copes with the Ether price fluctuations, 3) it lowers the computation overhead incurred by generating zk proofs e.g., instead of spending 100 different tokens each worth of x Ether (hence generating 100 proofs), one can spend one token worth of 100*x Ether