### PR TITLE
docs: add new version of store protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains specifications for the Waku suite of protocols.
 |[WAKU2-METADATA](standards/core/metadata.md)| Waku Metadata |
 |[WAKU2-NETWORK](standards/core/network.md)| Waku Network |
 |[RELAY-SHARDING](standards/core/relay-sharding.md)| Waku Relay Sharding |
-| WAKU2-STOREV3 | Coming Soon |
+|[WAKU2-STORE](standards/core/store.md) | Waku Store Query |
 
 ### Application standards
 

--- a/standards/core/store.md
+++ b/standards/core/store.md
@@ -390,4 +390,4 @@ Copyright and related rights waived via
 2. [protocol buffers v3](https://developers.google.com/protocol-buffers/)
 3. [11/WAKU2-RELAY](https://github.com/vacp2p/rfc-index/blob/7b443c1aab627894e3f22f5adfbb93f4c4eac4f6/waku/standards/core/11/relay.md)
 4. [Open timestamps](https://opentimestamps.org/) 
-
+5. [13/WAKU2-STORE v2 previous version](https://github.com/vacp2p/rfc-index/blob/7b443c1aab627894e3f22f5adfbb93f4c4eac4f6/waku/standards/core/13/store.md)

--- a/standards/core/store.md
+++ b/standards/core/store.md
@@ -1,7 +1,6 @@
 ---
 title: WAKU2-STORE
 name: Waku Store Query
-status: draft
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
   - Dean Eigenmann <dean@status.im>


### PR DESCRIPTION
After several rounds of review, the new Store protocol ("Store v3", although this should not be its official name) is now ready to be merged into the specs repo.

I've not updated everything in the spec, but have ensure that the links to rfc-index are working. I've also added a note to indicate this spec is earmarked to replace the current store RFC at some point.

As soon as this PR is merged, we can close the corresponding PR on the old RFC repo: https://github.com/vacp2p/rfc/pull/665
It may also be a good idea to restrict visibility to that deprecated repo to avoid any confusion.