### PR TITLE
chore: clarifications for node health when disparity in protocol health

### DIFF
--- a/standards/application/req-res-reliability.md
+++ b/standards/application/req-res-reliability.md
@@ -47,7 +47,7 @@ To address this we RECOMMEND following states:
 - sufficiently healthy:
   - Filter has at least 2 connections available to service nodes AND LightPush has at least 2 connections available to service nodes;
 
-If one of the protocols is unhealthy or minimally healthy, while the other is sufficiently healthy - overall node health SHOULD be considered as unhealthy or minimally healthy respectively.
+Overall node health SHOULD be considered as unhealthy or minimally healthy respectively if one of the protocols is unhealthy or minimally healthy, while the other is sufficiently healthy.
 
 ### Peers and connection management
 


### PR DESCRIPTION
## Problem

When talking about the Node health, it is categorised into two buckets:
- protocol health
- overall node health

When all the protocols report the same health metric, it's straightforward that the node health follows the same result.

In case where individual protocols report different health, we don't specify our recommendation.

## Suggested Solution

If there is a disparity in the node health for each protocol, we SHOULD derive the node health from the worse of the two.
Example: if LightPush has 2 peers (sufficiently healthy), but Filter has 0 available peers (unhealthy), overall node health should be reported as _unhealthy_

