### PR TITLE
Add WAKU2-RLN-CONTRACT spec for mainnet deployment

### DIFF
--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -13,12 +13,12 @@ This specification describes the smart contract that governs RLN memberships, in
 
 - the overall smart contract functionality;
 - contract parameters;
-- the values of those parameters for the initial deployment;
+- the values of those parameters for the initial deployment on a mainnet chain;
 - the way in which the parameters can be modified.
 
 ## Background
 
-Rate-Limiting Nullifiers (RLN) is a ZK-based rate-limiting technique used in Waku.
+[Rate-Limiting Nullifiers](https://rate-limiting-nullifier.github.io/rln-docs/) (RLN) is a ZK-based rate-limiting technique used in Waku.
 Before sending messages, users must register in a smart contract.
 They then attach a ZK proof of valid membership to every message.
 Relaying nodes check message validity and drop invalid messages.
@@ -34,19 +34,20 @@ which is necessary for proof generation and verification.
 
 In testnet deployment, the RLN contract does not require any payment apart from gas costs.
 This document aims to make the RLN contract suitable for mainnet deployment.
-In particular, the contract would require uses to put down a deposit.
+In particular, the contract would require users to put down a deposit.
 The aim of the deposit initially is purely to protect the system from abuse.
 It may also be explored as a revenue stream for Waku in later versions.
 
 ## Semantics
 
-The RLN contract provides the following functionality:
+The RLN contract provides the following functionalities:
 - register a membership in a given tier;
 - check if a membership is valid;
 - withdraw the deposit for an expired membership;
-- extend an expired membership.
+- get a merkle proof
+- get the merkle tree (root?)
 
-For the `Owner`, the contract provides the following additional functionality:
+For the _Contract Owner_, the contract provides the following additional functionality:
 - change the modifiable parameters (see parameter table below);
 - (TBD) freeze certain functionality (e.g., in case of an attack, stop new registrations, deposit withdrawals, etc).
 
@@ -57,7 +58,7 @@ In the initial deployment:
 
 ### Membership life-cycle
 
-To register a membership, a user puts locks up a deposit.
+To register a membership, a user locks up a deposit.
 Each membership has an expiration date.
 After a membership expires, it enters a grace period, during which the user can extend it.
 Extending a membership requires no additional deposit.
@@ -71,12 +72,12 @@ In more detail, the membership life-cycle is as follows:
 2. The user sends messages while the membership is active:
     1. If the user exceeds the rate limit, their over-limit messages are not propagated in that epoch; the deposit is not slashed.
 3. After the membership expires, the user can do one of the following:
-    1. Do nothing. The deposit remains in the contract, and the user retains the ability to send messages (respecting the per-epoch rate limit);
+    1. Do nothing. The deposit remains in the contract, and the user retains the ability to send messages (respecting the per-epoch rate limit); until another user takes their slot
     2. Withdraw the deposit. The user receives the full deposit back, and loses the ability to send messages;
     3. Extend the membership. The user sends a transaction to re-enable their membership for another expiration term. The user only covers gas costs and does not have to provide additional funds. The original deposit remains in the contract. The membership is prolonged for another expiration term under the same conditions.
 
 The user can extend the membership both during and after its grace period.
-By not extending the membership within its grace period, the user assumes the risk of the membership being taken over at any moment.
+By not extending the membership before the grace period expires, the user assumes the risk of the membership being taken over at any moment.
 
 A user can hold multiple memberships.
 Memberships are not transferable.
@@ -84,7 +85,7 @@ There is no limitation on the number of membership per user (apart from the glob
 
 ## Contract governance and mutability
 
-The contract governance is follows:
+The contract governance is as follows:
 
 1. the first deployment of the contract allows the `Owner` to modify certain parameters (TBD) under certain constraints (TBD);
 2. at some point, the `Onwer` would renounce their privileges, and the contract will become immutable;

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -1,0 +1,204 @@
+---
+title: WAKU2-RLN-CONTRACT
+name: Waku2 RLN Contract Specification
+category: Standards Track
+tags: [waku/core-protocol]
+editor: Sergei Tikhomirov <sergei@status.im>
+contributors:
+---
+
+## Abstract
+
+This specification describes the smart contract that governs RLN memberships, in particular:
+
+- the overall smart contract functionality;
+- contract parameters;
+- the values of those parameters for the initial deployment;
+- the way in which the parameters can be modified.
+
+## Background
+
+Rate-Limiting Nullifiers (RLN) is a ZK-based rate-limiting technique used in Waku.
+Before sending messages, users must register in a smart contract.
+They then attach a ZK proof of valid membership to every message.
+Relaying nodes check message validity and drop invalid messages.
+
+A message is considered valid in terms of RLN if:
+- its sender has an active RLN membership; and
+- the sender hasn't exceeded their rate limit within the current epoch.
+
+RLN is managed by a smart contract that keeps track of active memberships.
+Users interact with the contract to register a new membership and
+to obtain Merkle proofs and the tree root,
+which is necessary for proof generation and verification.
+
+In testnet deployment, the RLN contract does not require any payment apart from gas costs.
+This document aims to make the RLN contract suitable for mainnet deployment.
+In particular, the contract would require uses to put down a deposit.
+The aim of the deposit initially is purely to protect the system from abuse.
+It may also be explored as a revenue stream for Waku in later versions.
+
+## Semantics
+
+The RLN contract provides the following functionality:
+- register a membership in a given tier;
+- check if a membership is valid;
+- withdraw the deposit for an expired membership;
+- extend an expired membership.
+
+For the `Owner`, the contract provides the following additional functionality:
+- change the modifiable parameters (see parameter table below);
+- (TBD) freeze certain functionality (e.g., in case of an attack, stop new registrations, deposit withdrawals, etc).
+
+In the initial deployment:
+- there is no slashing;
+- membership expiration includes a grace period;
+- a user can extend their membership without putting up any additional deposit.
+
+### Membership life-cycle
+
+To register a membership, a user puts locks up a deposit.
+Each membership has an expiration date.
+After a membership expires, it enters a grace period, during which the user can extend it.
+Extending a membership requires no additional deposit.
+After the grace period, an expired membership can be taken over by another user.
+At any point, a user can withdraw their deposit and terminate the membership.
+
+In more detail, the membership life-cycle is as follows:
+1. A user registers a membership:
+    1. If there are expired unclaimed slots in the tree, use the slot with the earliest expiration date past its grace period, otherwise create a new slot;
+    2. if the membership re-uses a previously used slot, refund the previous user’s deposit.
+2. The user sends messages while the membership is active:
+    1. If the user exceeds the rate limit, their over-limit messages are not propagated in that epoch; the deposit is not slashed.
+3. After the membership expires, the user can do one of the following:
+    1. Do nothing. The deposit remains in the contract, and the user retains the ability to send messages (respecting the per-epoch rate limit);
+    2. Withdraw the deposit. The user receives the full deposit back, and loses the ability to send messages;
+    3. Extend the membership. The user sends a transaction to re-enable their membership for another expiration term. The user only covers gas costs and does not have to provide additional funds. The original deposit remains in the contract. The membership is prolonged for another expiration term under the same conditions.
+
+The user can extend the membership both during and after its grace period.
+By not extending the membership within its grace period, the user assumes the risk of the membership being taken over at any moment.
+
+A user can hold multiple memberships.
+Memberships are not transferable.
+There is no limitation on the number of membership per user (apart from the global limits, see parameter table).
+
+## Contract governance and mutability
+
+The contract governance is follows:
+
+1. the first deployment of the contract allows the `Owner` to modify certain parameters (TBD) under certain constraints (TBD);
+2. at some point, the `Onwer` would renounce their privileges, and the contract will become immutable;
+3. further upgrades, if necessary, can be done by deploying a new contract and moving the membership set.
+
+## Parameters
+
+We make the following design choices:
+- there are `3` membership tiers: low-, mid-, and high-tier;
+- prices are quoted in `USD`;
+- payment is accepted in `DAI`;
+- the price for a given tier is linearly proportional to its rate limit.
+
+For the initial deployment, we suggest the following values.
+
+| Parameter                                                 | Symbol     | Value   | Units                             | Modifiable? | Comment                        |
+| --------------------------------------------------------- | ---------- | ------- | --------------------------------- | ----------- | ------------------------------ |
+| Epoch length                                              | `epoch`    | `10`    | minutes                           | TBD         |                                |
+| Maximum total rate limit of concurrent active memberships | `R_{max}`  | TBD     | messages per `epoch`              | Yes         | Can be replaced with `N_{max}` |
+| Maximum number of concurrent active memberships           | `N_{max}`  | `10000` | units                             | Yes         | Can be replaced with `R_{max}` |
+| Rate limit for low-tier                                   | `R_{low}`  | `20`    | messages per `epoch`              | TBD         |                                |
+| Rate limit for mid-tier                                   | `R_{mid}`  | `200`   | messages per `epoch`              | TBD         |                                |
+| Rate limit for high-tier                                  | `R_{high}` | `600`   | messages per `epoch`              | TBD         |                                |
+| Unit price                                                | `p_u`      | TBD     | `USD` per `1` message per `epoch` | Yes         |                                |
+| Membership expiration term                                | `T`        | `90`    | days                              | Yes         |                                |
+| Grace period                                              | `G`        | `30`    | days                              | Yes         |                                |
+
+### Discussion on some parameter values
+
+#### Epoch length
+
+Epoch length is a global parameter set in the smart contract.
+Rate limits are defined in terms of the maximum allowed messages per epoch.
+There is a trade-off between short and long epochs.
+
+On the one hand, longer epochs allow for short-term spikes,
+which allows for more flexibility.
+Arguably, short-term bursts followed by a period of silence is a common pattern for some use cases.
+Usage peaks are expected to average out over longer time periods,
+allowing us to reason about network utilization on a longer time scale.
+
+On the other hand, long epochs lead to more memory requirements for nodes due to the growth of the nullifier log.
+Each message contains a nullifier that proves its validity in terms of RLN.
+Within the latest epoch, each relaying node stores all nullifiers to detect users exceeding the rate limit.
+Each nullifier plus metadata is `128` bytes (per message).
+This means that one user with a `1` message per second rate limit (high-tier) generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per 10-min epoch.
+
+#### Maximum total message limit / concurrently active memberships
+
+We may want to limit the total rate limit available to all users.
+The rationale is that the total network bandwidth is a limited resource.
+The total active rate limit should not exceed the network's real capabilities.
+
+There may be two ways to implement a global cap:
+- limit the total rate limits;
+- limit the total number of active memberships (e.g., at 10K memberships).
+
+#### Proportional pricing
+
+We suggest proportional pricing for simplicity.
+Proportional pricing means that if tier A offers N times the limit of tier B, then tier A is N times more expensive than tier B.
+
+An alternative approach could be bulk discounts for high-tier memberships.
+Discounts are more efficient but promote centralization.
+Finding the right trade-off remains subject for future work.
+
+#### Accepted tokens
+
+When choosing a token to accept, we consider the following criteria:
+
+- a stablecoin: USD-denominated pricing is simpler for users and for developers (avoiding an oracle);
+- popular, high liquidity;
+- preferably decentralized;
+- with a reasonably good track record w.r.t. censorship.
+
+Based on these criteria, we suggest accepting DAI for the initial deployment.
+Other tokens may be added in the future.
+
+#### Grace period and membership extension
+
+On the one hand, memberships must expire,
+otherwise a one-time payment would give a user the right to potentially infinite resource usage.
+On the other hand, the “soft” expiration suggested above is likely sufficient
+while balancing abuse prevention and ease of implementation:
+
+- although extending a membership doesn’t require a new deposit, keeping the original deposit locked up plus paying gas fees imposes cost on membership extension;
+- a legitimate user is unlikely to risk their membership being taken over at any moment by not renewing their membership.
+
+## Implementation Suggestions
+
+The current version of the contract (RLNv2) is deployed on Sepolia testnet ([source code](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol)).
+
+## Security / Privacy Considerations
+
+Requesting a Merkle proof for one's own membership through a third-party RPC provider may endanger the requester's privacy.
+
+## Future work
+
+In the future version of RLN contract, the following research directions might be pursued:
+- deposit slashing for misbehaving users;
+- extracting revenue by e.g. only allowing partial deposit withdrawal;
+- incentivization for relaying nodes;
+- non-proportional pricing (e.g., high-tier discounts);
+- accepting other tokens;
+- making memberships transferable (e.g., in the form of an NFT);
+- establishing a free relaying market by economically linking demand with supply;
+- countering potential centralization of membership ownership.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## References
+
+- [11/WAKU2-RELAY](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/11/relay.md)
+- [17/WAKU2-RLN-RELAY](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/17/rln-relay.md)
+

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -96,14 +96,18 @@ Further upgrades, if necessary, SHOULD be done by deploying a new contract and m
 Membership registration is subject to the following conditions:
 - if there are _expired_ memberships in the contract, the new membership MUST overwrite an expired membership;
 - the new membership SHOULD overwrite the membership that had been in _expired_ state for the longest time;
-- if the new membership overwrites another membership, the latter MUST transition from _expired_ to _erased_ state;
+- if the new membership overwrites another membership:
+	- the latter MUST transition from _expired_ to _erased_ state;
+	- the current total rate limit MUST be decremented by the rate limit of the newly _erased_ membership;
 - if the deposit from the newly _erased_ membership has not been withdrawn, the contract MUST take all necessary steps to ensure that the owner of that membership can withdraw their deposit later;
 - registration MUST fail if the total rate limit of _active_, _grace-period_, and _expired_ memberships, including the one being created, would exceed the limit;
 - registration MUST fail if the requested rate limit for the new membership is lower than allowed;
 - the user MUST lock-up a deposit to register a membership;
 - the user MUST specify the requested rate limit of the new membership;
 - the size of the deposit MUST be calculated depending on the requested rate limit;
-- in case of successful registration, the new membership MUST be in _active_ state;
+- in case of successful registration:
+	- the new membership MUST be in _active_ state;
+	- the current total rate limit MUST be incremented by the rate limit of the new membership;
 - a newly created membership MUST have an expiration time `T` and a grace period `G` (suggested values listed below).
 
 ### Send a message

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -192,6 +192,7 @@ and notify the user when their membership is about to expire.
 ### Why can't I withdraw a deposit from an _Active_ membership?
 
 The rationale for this limitation is to prevent an undesirable usage pattern where users make deposits and withdrawals in short succession.
+Such pattern may lead to network instability and should be carefully studied if seen as desirable.
 
 ### Why can't I extend an _Active_ membership?
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -9,35 +9,33 @@ contributors:
 
 ## Abstract
 
-This document specifies RLN membership management in the context of mainnet deployment of the RLN smart contract, in particular:
+This document describes membership management for the RLN smart contract, in particular:
 - membership-related contract functionality;
-- contract parameters for the initial mainnet deployment;
+- suggested parameters valued for the initial mainnet deployment;
 - contract governance and upgradability.
 
-We only consider contract functionality relevant for membership management.
-The document might later evolve into a full-fledged contract specification.
+This document currently only considers membership-related functionality.
+It might later evolve into a full-fledged contract specification.
+
+RLN is only deployed on Sepolia testnet ([source code](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol)) as of August 2024.
+This document aims to outline the path to its mainnet deployment.
 
 ## Background
 
-Rate-Limiting Nullifier (RLN) is a ZK-based gadget used in Waku.
-RLN provides a privacy-preserving way to limit each user's burden on the network.
+Rate-Limiting Nullifier (RLN) is a ZK-based gadget used for privacy-preserving rate limiting in Waku.
 The RLN smart contract is the core element of RLN architecture.
-Users interact with the contract to manage their memberships,
-as well as to get the data necessary for proof generation and verification.
+The smart contract stores the RLN tree that contains all currently existing memberships.
+Users interact with the contract to manage their memberships
+and to get the necessary data for proof generation and verification.
 
-To relay a message:
-- the sender MUST register a membership in a smart contract;
-- the sender MUST attach a ZK-proof of membership to every message;
-- each relaying node MUST relay a message unless:
-	- the message is committed to a different epoch than the current epoch; or
-	- the user has exceed their allowed rate limit for the current epoch; or
-	- the RLN proof fails to prove that the message sender holds a membership.
+Sending messages is handled by Waku Relay nodes.
+To send a message, the sender MUST attach a ZK-proof to the message.
+A Relay node MUST relay a message unless:
+- the message belongs to any epoch other than the current one; or
+- the user has exceed their allowed rate limit for the current epoch; or
+- the ZK-proof fails to prove that the sender holds a membership.
 
-Sending messages is handled by Waku Relay nodes, not by the RLN smart contract.
-The full specification of Relay node behavior is out of scope for this document.
-
-RLN is only deployed on Sepolia testnet as of August 2024.
-This document aims to outline the path to its mainnet deployment.
+The full specification of Relay is out of scope for this document.
 
 ## Contract overview
 
@@ -46,15 +44,7 @@ The contract MUST provide the following functionalities:
 - extend a membership;
 - withdraw a deposit.
 
-Availability of membership-specific functionalities MUST be as follows:
-
-|                       | Active | Grace Period | Expired | ErasedAwaitsWithdrawal | Erased |
-| --------------------- | ------ | ------------ | ------- | ---------------------- | ------ |
-| Send a message        | Yes    | Yes          | Yes     | No                     | No     |
-| Extend the membership | No     | Yes          | No      | No                     | No     |
-| Withdraw the deposit  | No     | Yes          | Yes     | Yes                    | No     |
-
-Contract parameters and their RECOMMENDED values are as follows:
+Contract parameters and their RECOMMENDED values for the initial mainnet deployment are as follows:
 
 | Parameter                                   | Symbol    | Value   | Units                              |
 | ------------------------------------------- | --------- | ------- | ---------------------------------- |
@@ -77,9 +67,9 @@ Any existing membership MUST always be in exactly one of the following states:
 ```mermaid
 graph TD;
     NonExistent --> |"register"| Active;
-    Active --> |"time `T` passed"| GracePeriod;
+    Active --> |"time T passed"| GracePeriod;
     GracePeriod --> |"extend"| Active;
-    GracePeriod --> |"time `G` passed"| Expired;
+    GracePeriod --> |"time G passed"| Expired;
     GracePeriod --> |"withdraw"| Erased;
     Expired --> |"withdraw"| Erased;
     Expired --> |"another membership reuses slot"| ErasedAwaitsWithdrawal;
@@ -87,8 +77,9 @@ graph TD;
 
 ```
 
-State updates triggered by a transaction MUST be applied immediately.
-State updates defined by time progression MAY be applied lazily.
+State updates triggered by a transaction (e.g., from _GracePeriod_ to _Active_ as a result of `extend`) MUST be applied immediately.
+State updates defined by time progression (e.g., from _GracePeriod_ to _Expired_ after time `G`) MAY be applied lazily.
+
 When providing any membership-specific functionality, the contract MUST:
 - check whether the state of the membership involved is up-to-date;
 - if necessary, update the membership state;
@@ -96,51 +87,63 @@ When providing any membership-specific functionality, the contract MUST:
 
 Memberships MUST be included in the RLN tree according to the following table:
 
-| State                  | Included in the tree |
-| ---------------------- | -------------------- |
-| Active                 | Yes                  |
-| GracePeriod            | Yes                  |
-| Expired                | Yes                  |
-| ErasedAwaitsWithdrawal | No                   |
-| Erased                 | No                   |
+| State                    | Included in the RLN tree |
+| ------------------------ | ------------------------ |
+| _Active_                 | Yes                      |
+| _GracePeriod_            | Yes                      |
+| _Expired_                | Yes                      |
+| _ErasedAwaitsWithdrawal_ | No                       |
+| _Erased_                 | No                       |
 
 Memberships MUST NOT be transferable.
 A user MAY use one Ethereum address to manage multiple memberships.
-A user MAY use one Waku node to manage multiple memberships. ^1
+A user MAY use one Waku node to manage multiple memberships. [^1]
 
 [^1]: No Waku implementation supports managing multiple memberships from one node (as of August 2024).
 
 
 ## Contract functionalities
 
+Availability of membership-specific functionalities MUST be as follows:
+
+|                       | Active | GracePeriod | Expired | ErasedAwaitsWithdrawal | Erased |
+| --------------------- | ------ | ----------- | ------- | ---------------------- | ------ |
+| Send a message        | Yes    | Yes         | Yes     | No                     | No     |
+| Extend the membership | No     | Yes         | No      | No                     | No     |
+| Withdraw the deposit  | No     | Yes         | Yes     | Yes                    | No     |
+Sending a message is included here for completeness,
+although it is part of the Relay protocol and not the RLN contract.
+
 ### Register a membership
 
 Membership registration is subject to the following conditions:
-- if there are _Expired_ memberships in the contract, the new membership MUST overwrite an expired membership;
+- if there are _Expired_ memberships in the RLN tree, the new membership MUST overwrite an _Expired_ membership;
 - the new membership SHOULD overwrite the membership that had been _Expired_ for the longest time;
-- if an _Expired_ membership A is overwritten by membership B:
-	- membership B MUST transition to _ErasedAwaitsWithdrawal_;
+- if a new membership A overwrites an _Expired_ membership B:
+	- membership B MUST become _ErasedAwaitsWithdrawal_;
 	- the current total rate limit MUST be decremented by the rate limit of membership B;
 	- the contract MUST take all necessary steps to ensure that the holder of membership B can withdraw their deposit later;
-- registration MUST fail if the total rate limit of _Active_, _GracePeriod_, and _Expired_ memberships, including the one being created, would exceed the limit;
-- registration MUST fail if the requested rate limit for the new membership is lower than the minimal allowed rate limit;
+- registration MUST fail if the total rate limit of _Active_, _GracePeriod_, and _Expired_ memberships, including the one being created, would exceed the maximum total rate;
+- registration MUST fail if the requested rate limit for a new membership is lower than the minimal allowed rate limit;
 - the user MUST lock-up a deposit to register a membership;
-- the user MUST specify the rate limit of the new membership;
-- the size of the deposit MUST be calculated depending on the requested rate limit;
-- in case of successful registration:
-	- the new membership MUST be in the _Active_ state;
+- the user MUST specify the rate limit of the new membership[^2];
+- the size of the deposit MUST depend on the requested rate limit;
+- in case of a successful registration:
+	- the new membership MUST become _Active_;
 	- the current total rate limit MUST be incremented by the rate limit of the new membership;
-- a newly created membership MUST have an expiration time `T` and a grace period `G` (see RECOMMENDED parameter values below).
+- a newly created membership MUST have an expiration time `T` and a grace period `G`.
+
+[^2]: A user-facing application SHOULD suggest default values for rate limits for the user.
 
 ### Extend a membership
 
-Extending a membership is subject to the following condition:
+Extending a membership is subject to the following conditions:
 - extension MUST fail if the membership is in any state other than _GracePeriod_;
 - the membership holder MUST be able to extend their membership;
 - any user except the membership holder MUST NOT be able to extend a membership;
 - after a successful extension, the membership MUST become _Active_.
 
-Owning a membership means controlling the private key from which the RLN commitment ID (i.e., public key) was derived.
+Holding a membership means controlling the private key from which the RLN commitment ID (i.e., public key) was derived.
 
 ### Withdraw the deposit
 
@@ -149,23 +152,21 @@ Deposit withdrawal is subject to the following conditions:
 - any user except the membership holder MUST NOT be able to withdraw its deposit;
 - a deposit MUST be withdrawn in full;
 - a withdrawal MUST fail if the membership is not in _GracePeriod_, _Expired_, or _ErasedAwaitsWithdrawal_;
-- any withdrawal MUST move the membership to _Erased_.
+- a membership MUST become _Erased_ after withdrawal.
 
 ## Governance and upgradability
 
 At initial mainnet deployment, the contract MUST have an _Owner_.
 The _Owner_ MUST be able to change the values of all contract parameters.
 The _Owner_ MUST be able to pause any of the following contract functionalities:
-	- register a membership;
-	- extend a membership;
-	- withdraw a deposit.
+- register a membership;
+- extend a membership;
+- withdraw a deposit.
 
 At some point, the _Owner_ SHOULD renounce their privileges, and the contract MUST become immutable.
 Further upgrades, if necessary, SHOULD be done by deploying a new contract and migrating the membership set.
 
 ## Implementation Suggestions
-
-The current version of the contract (RLNv2) is deployed on Sepolia testnet ([source code](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol)).
 
 User-facing application SHOULD suggest a few rate limits (tiers) to simplify their users' choice.
 The RECOMMENDED rate limits in a three-tier model are as follows:
@@ -195,30 +196,31 @@ The rationale for this limitation is to prevent an undesirable usage pattern whe
 
 Memberships can only be extended during _GracePeriod_.
 We do not allow extending an _Active_ membership.
-The rationale is that if the _Owner_ changes some contract parameters (e.g., for security purposes),
+The rationale is that if the contract _Owner_ changes some contract parameters (e.g., for security purposes),
 users with extended memberships will not be affected by the changes for a long time.
 
 ### What if I don't extend my membership within its _GracePeriod_?
 
-The user who does not extend their _GracePeriod_ membership, assumes the risk of the membership being overwritten at any moment.
-We expect that most users would not want to take that risk and would either extend their memberships or withdraw their deposits.
+The user who does not extend their _GracePeriod_ membership, 
+assume the risk of the membership being overwritten at any moment.
+We expect that most users would not want to take that risk 
+and would either extend their memberships or withdraw their deposits.
 
 ### Can I send messages when my membership is _Expired_?
 
 An _Expired_ membership allows sending messages for some time.
-
-Sending messages is managed by Relay nodes, not by RLN contract.
-The RLN proof that message senders provide to Relay nodes only proves whether the sender owns _some_ membership included in the RLN tree.
-The sender cannot prove the state of that membership.
+Sending messages is managed by Relay nodes.
+The RLN proof that message senders provide to Relay nodes doesn't prove the state of that membership.
 
 _Expired_ memberships are not erased from the tree proactively.
-An _Expired_ membership is only erased when either a new membership overwrites it, or when its deposit is withdrawn.
+An _Expired_ membership is only erased when either a new membership overwrites it,
+or when its deposit is withdrawn.
 After a membership is erased, it can no longer be used for sending messages.
 
 ### Will my deposit be slashed if I exceed the rate limit?
 
+This specification does not involve slashing.
 The aim of the deposit initially is to protect the network from denial-of-service attacks with bandwidth capping.
-The current version of RLN does not involve slashing.
 
 ### Do I need an extra deposit to extend a membership?
 
@@ -230,16 +232,13 @@ The opportunity cost of locked-up capital plus gas fees for extension transactio
 Epoch length is a global parameter set in the smart contract.
 Rate limits are defined in terms of the maximum allowed messages per epoch.
 There is a trade-off between short and long epochs.
+We chose an epoch length of `10` minutes as a reasonable middle-ground.
 
 On the one hand, longer epochs allow for better accommodating short-term usage peaks.
-Peaks tend to average out over longer time periods,
-which allows us to reason about network utilization on a longer time scale.
-
 On the other hand, long epochs increases memory requirements for Relay nodes.
+
 Each message contains a nullifier that proves its validity in terms of RLN.
 Each Relay node must keeps in memory a nullifier log for the current epoch.
-
-We chose an epoch length of `10` minutes as a reasonable middle-ground.
 Each nullifier plus metadata is `128` bytes (per message).
 With a `10`-minute epoch, one high-tier user with a `1` message per second rate limit generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per epoch.
 This corresponds to:
@@ -257,11 +256,11 @@ The minimal rate limit prevents an attack where someone registers a large number
 
 ### Are there bulk discounts for high-rate memberships?
 
-For the initial mainnet deployment, membership price is linearly proportional to its rate limit.
+For the initial mainnet deployment, there are no bulk discounts.
+Membership price is linearly proportional to its rate limit.
 We choose this pricing scheme for simplicity.
-In other words, there are no bulk discounts.
-High-rate memberships are arguably more efficient but can incentivize centralization.
-Finding a pricing scheme with the right trade-off remains subject for future work.
+Finding a pricing scheme with the right trade-off remains subject for future work, as
+high-rate memberships are arguably more efficient but can incentivize centralization.
 
 ### Why only accept DAI?
 
@@ -269,7 +268,7 @@ When choosing a token to accept, we considered the following criteria:
 - a stablecoin, as USD-denominated pricing is familiar for users and requires no oracle;
 - popular, high liquidity;
 - preferably decentralized;
-- with a reasonably good track record w.r.t. censorship.
+- with a reasonably good anti-censorship track record.
 
 Based on these criteria, we chose DAI for the initial mainnet deployment.
 Other tokens may be added in the future.
@@ -277,10 +276,11 @@ Other tokens may be added in the future.
 ## Security / Privacy Considerations
 
 Issuing membership-specific transactions (e.g., membership extension and deposit withdrawal) publicly links it to an Ethereum address.
-Note that this does not degrade the privacy of the relayed messages.
+Note that this does not degrade the privacy of the relayed messages,
+as message validation doesn't require the sender to disclose which membership they hold.
 
-To produce an RLN proof, a message sender must obtain a Merkle proof for their RLN membership.
-One way to obtain this proof is to request it from the RLN smart contract.
+To produce an RLN proof, a message sender must obtain a Merkle proof that their membership belongs to the RLN tree.
+One way to obtain this proof is to request it from the smart contract itself.
 Requesting a proof through a third-party RPC provider may endanger the sender's privacy.
 The provider would be able to link the requester's Ethereum address and the RLN membership with the corresponding API key.
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -46,14 +46,14 @@ The contract MUST provide the following functionalities:
 
 Contract parameters and their RECOMMENDED values for the initial mainnet deployment are as follows:
 
-| Parameter                                   | Symbol    | Value   | Units                              |
-| ------------------------------------------- | --------- | ------- | ---------------------------------- |
-| Epoch length                                | `epoch`   | `10`    | minutes                            |
-| Maximum total rate limit of all memberships | `R_{max}` | `20000` | messages per `epoch`               |
-| Minimal rate limit of one membership        | `r_{min}` | `20`    | messages per `epoch`               |
-| Price of `1` message per epoch              | `p_u`     | `0.01`  | `USD` per one period of length `T` |
-| Membership expiration term                  | `T`       | `180`   | days                               |
-| Membership grace period                     | `G`       | `30`    | days                               |
+| Parameter                                   | Symbol    | Value   | Units                |
+| ------------------------------------------- | --------- | ------- | -------------------- |
+| Epoch length                                | `epoch`   | `10`    | minutes              |
+| Maximum total rate limit of all memberships | `R_{max}` | `20000` | messages per `epoch` |
+| Minimal rate limit of one membership        | `r_{min}` | `20`    | messages per `epoch` |
+| Membership price for `1` message per epoch  | `p_u`     | `0.01`  | `USD`                |
+| Membership expiration term                  | `T`       | `180`   | days                 |
+| Membership grace period                     | `G`       | `30`    | days                 |
 
 ## Membership lifecycle
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -169,12 +169,10 @@ Further upgrades, if necessary, SHOULD be done by deploying a new contract and m
 
 ## Implementation Suggestions
 
-User-facing application SHOULD suggest a few rate limits (tiers) to simplify their users' choice.
-The RECOMMENDED rate limits in a three-tier model are as follows:
+User-facing application SHOULD suggest one or a few rate limits (tiers) to simplify their users' choice among the following RECOMMENDED rate limits:
 - `20` messages per epoch as low-tier;
 - `200` messages per epoch as mid-tier;
 - `600` messages per epoch as high-tier.
-Users SHOULD be able to select a custom rate limit under advanced settings.
 
 The RECOMMENDED pricing parameters are:
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -56,6 +56,7 @@ Contract parameters and their RECOMMENDED values for the initial mainnet deploym
 | Epoch length                                | `epoch`   | `10`     | minutes              |
 | Maximum total rate limit of all memberships | `R_{max}` | `160000` | messages per `epoch` |
 | Minimal rate limit of one membership        | `r_{min}` | `20`     | messages per `epoch` |
+| Maximum rate limit of one membership        | `r_{max}` | `600`    | messages per `epoch` |
 | Membership price for `1` message per epoch  | `p_u`     | `0.05`   | `USD`                |
 | Membership expiration term                  | `T`       | `180`    | days                 |
 | Membership grace period                     | `G`       | `30`     | days                 |
@@ -132,8 +133,8 @@ Membership registration is subject to the following conditions:
 	- membership B MUST become _ErasedAwaitsWithdrawal_;
 	- the current total rate limit MUST be decremented by the rate limit of membership B;
 	- the contract MUST take all necessary steps to ensure that the keeper of membership B can withdraw their deposit later;
-- registration MUST fail if the total rate limit of _Active_, _GracePeriod_, and _Expired_ memberships, including the one being created, would exceed the maximum total rate;
-- registration MUST fail if the requested rate limit for a new membership is lower than the minimal allowed rate limit;
+- registration MUST fail if the total rate limit of _Active_, _GracePeriod_, and _Expired_ memberships, including the one being created, would exceed `R_{max}`;
+- registration MUST fail if the requested rate limit for a new membership is lower than `r_{min}` or higher than `r_{max}`;
 - the user MUST lock-up a deposit to register a membership;
 - the user MUST specify the rate limit of the new membership[^2];
 - the size of the deposit MUST depend on the requested rate limit;

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -54,6 +54,9 @@ Contract parameters and their RECOMMENDED values for the initial mainnet deploym
 | Membership price for `1` message per epoch  | `p_u`     | `0.01`  | `USD`                |
 | Membership expiration term                  | `T`       | `180`   | days                 |
 | Membership grace period                     | `G`       | `30`    | days                 |
+| Accepted tokens                             |           | `DAI`   |                      |
+
+The pricing function SHOULD be linear in the rate limit per epoch.
 
 ## Membership lifecycle
 
@@ -173,14 +176,6 @@ User-facing application SHOULD suggest one or a few rate limits (tiers) to simpl
 - `20` messages per epoch as low-tier;
 - `200` messages per epoch as mid-tier;
 - `600` messages per epoch as high-tier.
-
-The RECOMMENDED pricing parameters are:
-
-| Parameter          | Value  |
-| ------------------ | ------ |
-| Accepted tokens    | `DAI`  |
-| Reference currency | `USD`  |
-| Pricing function   | linear |
 
 User-facing applications SHOULD save membership expiration dates in a local keystore during registration,
 and notify the user when their membership is about to expire.

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -9,15 +9,15 @@ contributors:
 
 ## Abstract
 
-This document describes membership management for the RLN smart contract, in particular:
+This document describes membership management within the RLN smart contract, specifically addressing:
 - membership-related contract functionality;
-- suggested parameters valued for the initial mainnet deployment;
+- suggested parameter values for the initial mainnet deployment;
 - contract governance and upgradability.
 
-This document currently only considers membership-related functionality.
-It might later evolve into a full-fledged contract specification.
+Currently, this document focuses solely on membership-related functionality.
+It might later evolve into a comprehensive contract specification.
 
-RLN is only deployed on Sepolia testnet ([source code](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol)) as of August 2024.
+As of August 2024, RLN is deployed only on Sepolia testnet ([source code](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol)).
 This document aims to outline the path to its mainnet deployment.
 
 ## Syntax
@@ -26,16 +26,16 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 ## Background
 
-Rate-Limiting Nullifier (RLN) is a ZK-based gadget used for privacy-preserving rate limiting in Waku.
-The RLN smart contract is the core element of RLN architecture.
-The smart contract stores the RLN tree that contains all currently existing memberships.
+Rate-Limiting Nullifier (RLN) is a Zero-Knowledge (ZK) based gadget used for privacy-preserving rate limiting in Waku.
+The RLN smart contract (referred to as "the contract" hereinafter) is the central component of the RLN architecture.
+The contract stores the RLN tree, which contains all current memberships.
 Users interact with the contract to manage their memberships
-and to get the necessary data for proof generation and verification.
+and obtain the necessary data for proof generation and verification.
 
-Sending messages is handled by Waku RLN Relay nodes.
-To send a message, the sender MUST prove its validity in terms of RLN.
+Message transmission is handled by Waku RLN Relay nodes.
+The sender of a message MUST prove its validity according to RLN requirements.
 RLN Relay nodes MUST NOT relay invalid messages.
-See [17/WAKU2-RLN-RELAY](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/17/rln-relay.md) for the full specification of RLN Relay.
+For the full specification of RLN Relay, see See [17/WAKU2-RLN-RELAY](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/17/rln-relay.md).
 
 ## Contract overview
 
@@ -44,23 +44,25 @@ The contract MUST provide the following functionalities:
 - extend a membership;
 - withdraw a deposit.
 
-A membership _holder_ is the entity that controls the secret of the respective RLN commitment.
-A membership _keeper_ is the entity that controls the Ethereum address that registered that membership.
-The holder and the keeper MAY differ for the same membership.
-The contract SHOULD only distinguish between the keeper and non-keepers when authorizing membership-related requests.
+A membership _holder_ is the entity that controls the secret associated with the respective RLN commitment.
+A membership _keeper_ is the entity that controls the Ethereum address used to register that membership.
+The holder and the keeper MAY be different entities for the same membership.
+When authorizing membership-related requests,
+the contract SHOULD distinguish between the keeper and non-keepers,
+and MAY also use additional criteria.
 
 Contract parameters and their RECOMMENDED values for the initial mainnet deployment are as follows:
 
-| Parameter                                   | Symbol    | Value    | Units                |
-| ------------------------------------------- | --------- | -------- | -------------------- |
-| Epoch length                                | `epoch`   | `10`     | minutes              |
-| Maximum total rate limit of all memberships | `R_{max}` | `160000` | messages per `epoch` |
-| Minimal rate limit of one membership        | `r_{min}` | `20`     | messages per `epoch` |
-| Maximum rate limit of one membership        | `r_{max}` | `600`    | messages per `epoch` |
-| Membership price for `1` message per epoch  | `p_u`     | `0.05`   | `USD`                |
-| Membership expiration term                  | `T`       | `180`    | days                 |
-| Membership grace period                     | `G`       | `30`     | days                 |
-| Accepted tokens                             |           | `DAI`    |                      |
+| Parameter                                               | Symbol    | Value    | Units                |
+| ------------------------------------------------------- | --------- | -------- | -------------------- |
+| Epoch length                                            | `epoch`   | `10`     | minutes              |
+| Maximum total rate limit of all memberships in the tree | `R_{max}` | `160000` | messages per `epoch` |
+| Minimum rate limit of one membership                    | `r_{min}` | `20`     | messages per `epoch` |
+| Maximum rate limit of one membership                    | `r_{max}` | `600`    | messages per `epoch` |
+| Membership price for `1` message per epoch              | `p_u`     | `0.05`   | `USD`                |
+| Membership expiration term                              | `T`       | `180`    | days                 |
+| Membership grace period                                 | `G`       | `30`     | days                 |
+| Accepted tokens                                         |           | `DAI`    |                      |
 
 The pricing function SHOULD be linear in the rate limit per epoch.
 
@@ -89,10 +91,10 @@ graph TD;
 State updates triggered by a transaction (e.g., from _GracePeriod_ to _Active_ as a result of `extend`) MUST be applied immediately.
 State updates defined by time progression (e.g., from _GracePeriod_ to _Expired_ after time `G`) MAY be applied lazily.
 
-When providing any membership-specific functionality, the contract MUST:
-- check whether the state of the membership involved is up-to-date;
+When handling a membership-specific transaction, the contract MUST:
+- check whether the state of the involved membership is up-to-date;
 - if necessary, update the membership state;
-- process the transaction in accordance with the up-to-date membership state.
+- process the transaction in accordance with the updated membership state.
 
 Memberships MUST be included in the RLN tree according to the following table:
 
@@ -106,14 +108,14 @@ Memberships MUST be included in the RLN tree according to the following table:
 
 Memberships MUST NOT be transferable.
 A user MAY use one Ethereum address to manage multiple memberships.
-A user MAY use one Waku node to manage multiple memberships. [^1]
+A user MAY use one Waku node[^1] to manage multiple memberships.
 
 [^1]: No Waku implementation supports managing multiple memberships from one node (as of August 2024).
 
 
 ## Contract functionalities
 
-Availability of membership-specific functionalities MUST be as follows:
+Availability of membership-specific functionalities[^2] MUST be as follows:
 
 |                       | Active | GracePeriod | Expired | ErasedAwaitsWithdrawal | Erased |
 | --------------------- | ------ | ----------- | ------- | ---------------------- | ------ |
@@ -121,48 +123,45 @@ Availability of membership-specific functionalities MUST be as follows:
 | Extend the membership | No     | Yes         | No      | No                     | No     |
 | Withdraw the deposit  | No     | Yes         | Yes     | Yes                    | No     |
 
-Sending a message is included here for completeness,
-although it is part of the RLN Relay protocol and not the RLN contract.
+[^2]: Sending a message is included here for completeness, although it is part of the RLN Relay protocol and not the contract.
 
 ### Register a membership
 
 Membership registration is subject to the following conditions:
-- if there are _Expired_ memberships in the RLN tree, the new membership MUST overwrite an _Expired_ membership;
-- the new membership SHOULD overwrite the membership that had been _Expired_ for the longest time;
-- if a new membership A overwrites an _Expired_ membership B:
+- If there are _Expired_ memberships in the RLN tree, the new membership MUST overwrite an _Expired_ membership.
+- The new membership SHOULD overwrite the membership that has been _Expired_ for the longest time.
+- If a new membership A overwrites an _Expired_ membership B:
 	- membership B MUST become _ErasedAwaitsWithdrawal_;
 	- the current total rate limit MUST be decremented by the rate limit of membership B;
-	- the contract MUST take all necessary steps to ensure that the keeper of membership B can withdraw their deposit later;
-- registration MUST fail if the total rate limit of _Active_, _GracePeriod_, and _Expired_ memberships, including the one being created, would exceed `R_{max}`;
-- registration MUST fail if the requested rate limit for a new membership is lower than `r_{min}` or higher than `r_{max}`;
-- the user MUST lock-up a deposit to register a membership;
-- the user MUST specify the rate limit of the new membership[^2];
-- the size of the deposit MUST depend on the requested rate limit;
-- in case of a successful registration:
+	- the contract MUST take all necessary steps to ensure that the keeper of membership B can withdraw their deposit later.
+- Registration MUST fail if the total rate limit of _Active_, _GracePeriod_, and _Expired_ memberships, including the one being created, would exceed `R_{max}`.
+- Registration MUST fail if the requested rate limit for a new membership is lower than `r_{min}` or higher than `r_{max}`.
+- The keeper MUST lock up a deposit to register a membership.
+- The keeper MUST specify the rate limit[^3] of a membership at registration time.
+- The size of the deposit MUST depend on the specified rate limit.
+- In case of a successful registration:
 	- the new membership MUST become _Active_;
-	- the current total rate limit MUST be incremented by the rate limit of the new membership;
-- a newly created membership MUST have an expiration time `T` and a grace period `G`.
+	- the current total rate limit MUST be incremented by the rate limit of the new membership.
+- A membership MUST have an expiration time `T` and a grace period `G`.
 
-[^2]: A user-facing application SHOULD suggest default values for rate limits for the user.
+[^3]: A user-facing application SHOULD suggest default rate limits to the keeper (see Implementation Suggestions).
 
 ### Extend a membership
 
 Extending a membership is subject to the following conditions:
-- extension MUST fail if the membership is in any state other than _GracePeriod_;
-- the membership keeper MUST be able to extend their membership;
-- any user except the membership keeper MUST NOT be able to extend a membership;
-- after a successful extension, the membership MUST become _Active_.
-
-
+- The extension MUST fail if the membership is in any state other than _GracePeriod_.
+- The membership keeper MUST be able to extend their membership.
+- Any user other than the membership keeper MUST NOT be able to extend a membership.
+- After a successful extension, the membership MUST become _Active_.
 
 ### Withdraw the deposit
 
 Deposit withdrawal is subject to the following conditions:
-- the membership keeper MUST be able to withdraw their deposit;
-- any user except the membership keeper MUST NOT be able to withdraw its deposit;
-- a deposit MUST be withdrawn in full;
-- a withdrawal MUST fail if the membership is not in _GracePeriod_, _Expired_, or _ErasedAwaitsWithdrawal_;
-- a membership MUST become _Erased_ after withdrawal.
+- The membership keeper MUST be able to withdraw their deposit.
+- Any user other than the membership keeper MUST NOT be able to withdraw its deposit.
+- A deposit MUST be withdrawn in full.
+- A withdrawal MUST fail if the membership is not in _GracePeriod_, _Expired_, or _ErasedAwaitsWithdrawal_.
+- A membership MUST become _Erased_ after withdrawal.
 
 ## Governance and upgradability
 
@@ -173,12 +172,15 @@ The _Owner_ MUST be able to pause any of the following contract functionalities:
 - extend a membership;
 - withdraw a deposit.
 
-At some point, the _Owner_ SHOULD renounce their privileges, and the contract MUST become immutable.
-Further upgrades, if necessary, SHOULD be done by deploying a new contract and migrating the membership set.
+At some point, the _Owner_ SHOULD renounce their privileges,
+and the contract MUST become immutable.
+If further upgrades are necessary,
+a new contract SHOULD be deployed,
+and the membership set SHOULD be migrated.
 
 ## Implementation Suggestions
 
-User-facing application SHOULD suggest one or a few rate limits (tiers) to simplify their users' choice among the following RECOMMENDED rate limits:
+User-facing applications SHOULD suggest one or more rate limits (tiers) to simplify user selection among the following RECOMMENDED options:
 - `20` messages per epoch as low-tier;
 - `200` messages per epoch as mid-tier;
 - `600` messages per epoch as high-tier.
@@ -190,100 +192,107 @@ and notify the user when their membership is about to expire.
 
 ### Why can't I withdraw a deposit from an _Active_ membership?
 
-The rationale for this limitation is to prevent an undesirable usage pattern where users make deposits and withdrawals in short succession.
-Such pattern may lead to network instability and should be carefully studied if seen as desirable.
+The rationale for this limitation is to prevent a usage pattern where users make deposits and withdrawals in quick succession.  
+Such a pattern could lead to network instability and should be carefully considered if deemed desirable.
 
 ### Why can't I extend an _Active_ membership?
 
 Memberships can only be extended during _GracePeriod_.
-We do not allow extending an _Active_ membership.
-The rationale is that if the contract _Owner_ changes some contract parameters (e.g., for security purposes),
-users with extended memberships will not be affected by the changes for a long time.
+Extending an _Active_ membership is not allowed.
+The rationale is to make possible parameter changes that the contract _Owner_ might make (e.g., for security reasons) applicable to most memberships.
 
 ### What if I don't extend my membership within its _GracePeriod_?
 
-The user who does not extend their _GracePeriod_ membership, 
-assume the risk of their _Expired_ membership being overwritten.
-We expect, generally, that a user would not want to take that risk 
-and would either extend their membership or withdraw their deposit.
+If a user does not extend their membership during the _GracePeriod_,
+they risk having their _Expired_ membership overwritten.  
+Generally, users are expected to either extend their membership or withdraw their deposit to avoid this risk.
 
 ### Can I send messages when my membership is _Expired_?
 
-An _Expired_ membership allows sending messages for some time.
-Sending messages is managed by RLN Relay nodes.
-The RLN proof that message senders provide to RLN Relay nodes doesn't prove the state of that membership.
+An _Expired_ membership allows sending messages for a certain period.
+The RLN proof that message senders provide to RLN Relay nodes does not prove the state of the membership,
+only its inclusion in the tree.
 
-_Expired_ memberships are not erased from the tree proactively.
-An _Expired_ membership is only erased when either a new membership overwrites it,
-or when its deposit is withdrawn.
-After a membership is erased, it can no longer be used for sending messages.
+_Expired_ memberships are not proactively erased from the tree.  
+An _Expired_ membership is erased only when a new membership overwrites it or when its deposit is withdrawn.  
+Once erased (i.e., _Erased_ or _ErasedAwaitsWithdrawal_), the membership can no longer be used to send messages.
 
 ### Will my deposit be slashed if I exceed the rate limit?
 
-This specification does not involve slashing.
-The aim of the deposit initially is to protect the network from denial-of-service attacks with bandwidth capping.
+This specification does not include slashing.
+The deposit's current purpose is purely to protect the network from denial-of-service attacks through bandwidth capping.
 
-### Do I need an extra deposit to extend a membership?
+### Do I need an extra deposit to extend my membership?
 
 Membership extension requires no additional deposit.
-The opportunity cost of locked-up capital plus gas fees for extension transactions make extensions non-free, which is sufficient for the initial mainnet deployment.
+The opportunity cost of locked-up capital and gas fees for extension transactions make extensions non-free,
+which is sufficient for the initial mainnet deployment.
 
 ### Why this particular epoch length?
 
-Epoch length is a global parameter set in the smart contract.
+Epoch length is a global parameter defined in the contract.
 Rate limits are defined in terms of the maximum allowed messages per epoch.
-There is a trade-off between short and long epochs.
-We chose an epoch length of `10` minutes as a reasonable middle-ground.
 
-On the one hand, longer epochs allow for better accommodating short-term usage peaks.
-On the other hand, long epochs increases memory requirements for RLN Relay nodes.
+There is a trade-off between short and long epochs.
+Longer epochs accommodate short-term usage peaks better,
+but they increase memory requirements for RLN Relay nodes.
+An epoch length of `10` minutes was chosen as a reasonable middle ground.
 
 Each message contains a nullifier that proves its validity in terms of RLN.
-Each RLN Relay node must store in memory a nullifier log for the current epoch.
-Each nullifier plus metadata is `128` bytes (per message).
-With a `10`-minute epoch, one high-tier user with a `1` message per second rate limit generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per epoch.
-This corresponds to:
-- for 1000 users: approximately `73 MiB`;
-- for 10 thousand users: approximately `732 MiB`.
+Each RLN Relay node must store a nullifier log for the current epoch in memory.
+A nullifier plus metadata is `128` bytes per message.
+With a `10`-minute epoch, a high-tier user with a `1` message per second rate limit generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per epoch.
+This equates to, approximately:
+- `73 MiB` for 1000 users;
+- `732 MiB` for 10 thousand users.
 
 ### Why is there a cap on the total rate limit?
 
 Total network bandwidth is a limited resource.
-We want to cap the total rate limit, at least in the initial mainnet deployment, to avoid overstretching the network's capabilities.
+To avoid overstretching the network's capabilities for the initial mainnet deployment,
+we define a cap `R_{max}` on the total rate limit.
 
-### Why is there a minimal rate limit?
+### Why is there a minimum rate limit?
 
-The minimal rate limit prevents an attack where someone registers a large number of memberships with a tiny rate limit each, causing the RLN tree to contain too many elements.
+The minimum rate limit `r_{min}` prevents an attack where a large number of tiny memberships cause RLN tree bloat.
+
+### Why is there a maximum rate limit?
+
+The maximum rate limit `r_{max}` prevents any single actor from consuming an excessive portion of the total available rate limit.
+
+However, it is still possible for an attacker to register multiple Ethereum addresses,
+and occupy a significant portion of the total rate limit through several memberships.
 
 ### Are there bulk discounts for high-rate memberships?
 
-For the initial mainnet deployment, there are no bulk discounts.
+For the initial mainnet deployment, no bulk discounts are offered.
 Membership price is linearly proportional to its rate limit.
 We choose this pricing scheme for simplicity.
-Finding a pricing scheme with the right trade-off remains subject for future work, as
-high-rate memberships are arguably more efficient but can incentivize centralization.
+Future work may explore alternative pricing schemes that balance efficiency with centralization risk.
 
 ### Why only accept DAI?
 
 When choosing a token to accept, we considered the following criteria:
 - a stablecoin, as USD-denominated pricing is familiar for users and requires no oracle;
-- popular, high liquidity;
-- preferably decentralized;
-- with a reasonably good anti-censorship track record.
+- popular with high liquidity;
+- decentralized;
+- reasonably good censorship-resistance.
 
 Based on these criteria, we chose DAI for the initial mainnet deployment.
 Other tokens may be added in the future.
 
 ## Security / Privacy Considerations
 
-Issuing membership-specific transactions (e.g., membership extension and deposit withdrawal) publicly links it to an Ethereum address.
-Note that this does not degrade the privacy of the relayed messages,
-as message validation doesn't require the sender to disclose which membership they hold.
+Issuing membership-specific transactions,
+such as membership extensions and deposit withdrawals,
+publicly associates a membership with an Ethereum address.
+However, this association does not compromise the privacy of the relayed messages,
+as the protocol does not require the sender to disclose their specific membership to RLN Relay nodes.
 
-To produce an RLN proof, a message sender must obtain a Merkle proof that their membership belongs to the RLN tree.
-One way to obtain this proof is to request it from the smart contract itself.
-Requesting a proof through a third-party RPC provider may endanger the sender's privacy.
-The provider would be able to link the requester's Ethereum address and the RLN membership with the corresponding API key.
+To generate an RLN proof, a message sender must obtain a Merkle proof confirming that their membership belongs to the RLN tree.
+This proof can be requested directly from the contract.
+Requesting the proof through a third-party RPC provider could compromise the sender's privacy,
+as the provider might link the requester's Ethereum address, their RLN membership, and the corresponding API key.
 
 ## Copyright
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -52,7 +52,7 @@ Contract parameters and their RECOMMENDED values for the initial mainnet deploym
 | Maximum total rate limit of all memberships | `R_{max}` | `20000` | messages per `epoch`               |
 | Minimal rate limit of one membership        | `r_{min}` | `20`    | messages per `epoch`               |
 | Price of `1` message per epoch              | `p_u`     | `0.01`  | `USD` per one period of length `T` |
-| Membership expiration term                  | `T`       | `90`    | days                               |
+| Membership expiration term                  | `T`       | `180`   | days                               |
 | Membership grace period                     | `G`       | `30`    | days                               |
 
 ## Membership lifecycle
@@ -67,9 +67,9 @@ Any existing membership MUST always be in exactly one of the following states:
 ```mermaid
 graph TD;
     NonExistent --> |"register"| Active;
-    Active --> |"time T passed"| GracePeriod;
+    Active -.-> |"time T passed"| GracePeriod;
     GracePeriod --> |"extend"| Active;
-    GracePeriod --> |"time G passed"| Expired;
+    GracePeriod -.-> |"time G passed"| Expired;
     GracePeriod --> |"withdraw"| Erased;
     Expired --> |"withdraw"| Erased;
     Expired --> |"another membership reuses slot"| ErasedAwaitsWithdrawal;
@@ -204,8 +204,8 @@ users with extended memberships will not be affected by the changes for a long t
 
 The user who does not extend their _GracePeriod_ membership, 
 assume the risk of the membership being overwritten at any moment.
-We expect that most users would not want to take that risk 
-and would either extend their memberships or withdraw their deposits.
+We expect, generally, that a user would not want to take that risk 
+and would either extend their membership or withdraw their deposit.
 
 ### Can I send messages when my membership is _Expired_?
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -9,55 +9,35 @@ contributors:
 
 ## Abstract
 
-This specification describes the smart contract that governs RLN memberships, in particular:
+This document specifies RLN membership management in the context of mainnet deployment of the RLN smart contract, in particular:
+- membership-related contract functionality;
+- contract parameters for the initial mainnet deployment;
+- contract governance and upgradability.
 
-- the overall smart contract functionality;
-- contract parameters;
-- the values of those parameters for the initial deployment on a mainnet chain;
-- the way in which the parameters can be modified.
+We only consider contract functionality relevant for membership management.
+The document might later evolve into a full-fledged contract specification.
 
 ## Background
 
-[Rate-Limiting Nullifiers](https://rate-limiting-nullifier.github.io/rln-docs/) (RLN) is a ZK-based rate-limiting technique used in Waku.
-Before sending messages, users must register in a smart contract.
-They then attach a ZK proof of valid membership to every message.
-Relaying nodes check message validity and drop invalid messages.
+Rate-Limiting Nullifier (RLN) is a ZK-based gadget used in Waku.
+RLN provides a privacy-preserving way to limit each user's burden on the network.
+The RLN smart contract is the core element of RLN architecture.
+Users interact with the contract to manage their memberships,
+as well as to get the data necessary for proof generation and verification.
 
-A message is considered valid in terms of RLN if:
-- its sender has an active RLN membership; and
-- the sender hasn't exceeded their rate limit within the current epoch.
+To relay a message:
+- the sender MUST register a membership in a smart contract;
+- the sender MUST attach a ZK-proof of membership to every message;
+- each relaying node MUST drop the message if:
+	- the proof is invalid; or
+	- the sender has exceeded their rate limit within the current epoch.
 
-RLN is managed by a smart contract that keeps track of active memberships.
-Users interact with the contract to register a new membership and
-to obtain Merkle proofs and the tree root,
-which is necessary for proof generation and verification.
-
-In testnet deployment, the RLN contract does not require any payment apart from gas costs.
-This document aims to make the RLN contract suitable for mainnet deployment.
-In particular, the contract would require users to put down a deposit.
-The aim of the deposit initially is purely to protect the system from denial-of-service attacks using bandwidth capping.
-It may also be explored as a revenue stream for Waku in later versions.
+RLN is only deployed on Sepolia testnet as of August 2024.
+This document aims to outline the path to its mainnet deployment.
 
 ## Membership lifecycle
 
-This section is not intended to describe the full contract functionality.
-We only focus on functions required for managing memberships.
-The document might later evolve into a full-fledged contract specification.
-
-The RLN contract provides the following functionalities:
-- register a membership;
-- extend a membership;
-- terminate the membership (withdraw the deposit).
-
-For the _Contract Owner_, the contract provides the following additional functionality:
-- change the modifiable parameters (see parameter table below);
-- (TBD) freeze certain functionality (e.g., in case of an attack, stop new registrations, deposit withdrawals, etc).
-
-The deposit is not taken away (slashed) for exceeding the rate limit.
-
-## Membership state transitions
-
-A membership can be in one of the following states:
+Any existing membership MUST always be in exactly one of the following states:
 - active;
 - grace-period;
 - expired;
@@ -66,215 +46,222 @@ A membership can be in one of the following states:
 ```mermaid
 graph TD;
     NonExistent --> |"register"| Active;
-    Active --> |"+90 days"| GracePeriod;
+    Active --> |"time `T` passed"| GracePeriod;
     GracePeriod --> |"extend"| Active;
-    GracePeriod --> |"+30 days"| Expired;
+    GracePeriod --> |"time `G` passed"| Expired;
     GracePeriod --> |"withdraw"| Expired;
     Expired --> |"reuse_slot"| Erased;
 
 ```
 
-A user locks up a deposit to register a membership, which starts its lifecycle in the _active_ state.
-After the expiration term (see parameter table), a membership moves to the _grace period_ state.
-During grace period, the membership owner can either extend the membership or withdraw the deposit.
-Deposit withdrawal makes a _grace-period_ membership _expired_ immediately.
-Extension makes a _grace-period_ membership _active_ immediately.
-A _grace-period_ membership becomes _expired_ automatically after its grace period ends.
-The slot in the RLN tree of an _expired_ membership can be overridden by a new membership.
-An _expired_ membership becomes _erased_ when its tree slot is overridden.
+State updates triggered by a transaction MUST be updated immediately.
+State updates defined by time progression MAY be updated lazily.
+Before providing any membership-specific functionality, the contract MUST:
+- check whether the state of the membership involved is up-to-date;
+- if necessary, update the membership state;
+- process the transaction in accordance with the up-to-date membership state.
 
-The user can only extend their membership during its grace period.
-Otherwise, the user assumes the risk of the membership being erased at any moment.
-
-The user cannot withdraw their deposit from an _active_ membership.
-The rationale for this limitation is to prevent users from abusing the contract by making deposits and withdrawals in short succession.
-
-Memberships are not transferable.
+Memberships MUST NOT be transferable.
 One Ethereum address MAY register multiple memberships.
-One Waku node MAY manage multiple memberships,
-although this functionality is not yet implemented.
+One Waku node MAY manage multiple memberships (this functionality is not yet implemented as of August 2024).
 
-Availability of user functionalities depending on the membership state is as follows:
+## Contract functionalities
+
+The contract MUST provide the following functionalities:
+- register a membership;
+- extend a membership;
+- withdraw a deposit.
+
+Availability of membership-specific functionalities MUST be as follows:
 
 |                       | Active | Grace Period | Expired | Erased |
 | --------------------- | ------ | ------------ | ------- | ------ |
 | Send a message        | Yes    | Yes          | Yes     | No     |
 | Extend the membership | No     | Yes          | No      | No     |
 | Withdraw the deposit  | No     | Yes          | Yes     | Yes    |
+### Governance and upgradability
 
-Note that the user can still send messages when their membership is _expired_.
-This is explained by the fact that Relay nodes cannot verify the state of the membership, only its presence in the RLN tree.
-_Expired_ memberships are not erased from the tree proactively, as this would require someone to send a transaction and pay the gas costs.
-Instead, an _expired_ memberships is only erased when a new memberships overtakes its slot.
-We expect that an honest user would not want to risk their membership being erased at any time, and would either extend or terminate it during its grace period.
+At initial mainnet deployment, the contract MUST have an _Owner_ with the following additional functionalities:
+- change any of the modifiable parameters, as listed in the Parameter table;
+- disable any of the following contract functionalities:
+	- register a membership;
+	- extend a membership;
+	- (TBD) withdraw a deposit.
 
-We do not allow extending an _active_ membership.
-The rationale here is that if the _Owner_ changes some contract parameters (e.g., for security purposes),
-users with extended memberships will not be affected by the changes for a long time.
+At some point, the _Owner_ SHOULD renounce their privileges, and the contract MUST become immutable.
+Further upgrades, if necessary, SHOULD be done by deploying a new contract and migrating the membership set.
 
-Membership states are updated lazily in the contract.
-Before handling any membership-specific function, the contract MUST check if the membership's state is outdated and update it as necessary.
+### Register a membership
 
+Membership registration is subject to the following conditions:
+- if there are _expired_ memberships in the contract, the new membership MUST overwrite an expired membership;
+- the new membership SHOULD overwrite the membership that had been in _expired_ state for the longest time;
+- if the new membership overwrites another membership, the latter MUST transition from _expired_ to _erased_ state;
+- if the deposit from the newly _erased_ membership has not been withdrawn, the contract MUST take all necessary steps to ensure that the owner of that membership can withdraw their deposit later;
+- registration MUST fail if the total rate limit of _active_, _grace-period_, and _expired_ memberships, including the one being created, would exceed the limit;
+- registration MUST fail if the requested rate limit for the new membership is lower than allowed;
+- the user MUST lock-up a deposit to register a membership;
+- the user MUST specify the requested rate limit of the new membership;
+- the size of the deposit MUST be calculated depending on the requested rate limit;
+- in case of successful registration, the new membership MUST be in _active_ state;
+- a newly created membership MUST have an expiration time `T` and a grace period `G` (suggested values listed below).
 
-### User actions
+### Send a message
 
-In more detail, user actions are handled as follows.
+Sending messages is handled by Waku Relay nodes, not by the RLN smart contract.
+For completeness, sending messages is mentioned below where relevant as one of broader Waku functionalities.
+The full specification of Relay node behavior is out of scope for this document.
 
-#### Register a membership
+A Relay node MUST relay a message unless:
+- the message is committed to a different epoch than the current epoch; or
+- the user has exceed their allowed rate limit for the current epoch; or
+- the RLN proof fails to prove that the message sender owns an existing membership.
 
-Registering a membership:
-1. Check whether there are _expired_ memberships.
-	1. If there are _expired_ memberships:
-		1. Select the _expired_ membership with the earliest end of its grace period;
-		2. Move that membership to the _erased_ state;
-		3. Create a new _active_ membership using the erased membership's tree slot.
-	2. If there are no _expired_ memberships, check whether the total limits are respected.
-		1. If the new membership would exceed the maximum total number of _active_, _grace-period_, and _expired_ memberships, fail the registration;
-		2. If the new membership would exceed the maximum total rate limit of _active_, _grace-period_, and _expired_ memberships, fail the registration;
-		3. Otherwise, create a new membership in the _active_ state.
+### Extend a membership
 
-#### Send a message
+Extending a membership is subject to the following condition:
+- extension MUST fail if the membership is in any state other than _grace-period_;
+- the membership owner MUST be able to extend the membership;
+- any user except the membership owner MUST NOT be able to extend the membership;
+- after a successful extension, the membership MUST become _active_.
 
-Note: when sending a message, the user only interacts with a Relay node, not with the smart contract.
-The Relay node, in turn, interacts with the smart contract to check the user-provided RLN proof.
+Owning a membership means controlling the private key from which the RLN commitment ID (i.e., public key) was derived.
 
-Sending a message:
-1. If the message is committed to a different epoch than the current epoch, drop the message;
-2. If the user has exceed their allowed rate limit for the current epoch, drop the message;
-3. If the RLN proof fails, drop the message;
-4. Otherwise, propagate the message.
+### Withdraw the deposit
 
-#### Extend a membership
+Deposit withdrawal is subject to the following conditions:
+- the owner of a membership MUST be able to withdraw their deposit;
+- a deposit MUST be withdrawn in full;
+- any user except the membership owner MUST NOT be able to withdraw its deposit;
+- a withdrawal MUST fail if the membership is in any state other than _grace-period_, _expired_, or _erased_;
+- a withdrawal from a _grace-period_ membership MUST move it into the _expired_ state;
+- a withdrawal from an _expired_ membership MUST NOT change its state (TBD);
+- a withdrawal from an _erased_ membership MUST NOT change its state (TBD).
 
-(TBD) The contract doesn't check whether the transaction sender is the owner of the membership in question.
-In other words, any user is permitted to extend any _grace-period_ membership.
-
-Note: an attacker can extend other users' _grace-period_ memberships without their consent,
-which has at least two negative consequences:
-1. users who planned to withdraw their deposit later would have to wait for another membership term;
-2. if an attacker extends many memberships, the cap on total active rate limit can be exceeded, preventing the registration of new memberships.
-
-Extending a membership:
-1. Check whether the membership is in its _grace-period_ state:
-	1. If it is not, fail the transaction;
-	2. Otherwise, mark the membership as _active_.
-
-#### Withdraw the deposit
-
-Withdrawing the deposit:
-1. (TBD) Check whether the user is the "owner" of the membership:
-	1. If not, fail the transaction;
-	2. Otherwise, continue.
-2. Check whether the membership is in one of the states that allow withdrawal:
-	1. If not, fail the transaction;
-	2. Otherwise, continue.
-3. Check whether the deposit has not yet been withdrawn:
-	1. If not, fail the transaction;
-	2. Otherwise, withdraw the deposit.
-
-(TBD) If an _expired_ membership becomes _erased_,
-and its deposit has not been withdrawn,
-data is saved in the smart contract that would allow the user to withdraw the deposit later.
-
-## Contract governance and mutability
-
-The contract governance is as follows:
-
-1. the first deployment of the contract allows the _Owner_ to modify certain parameters (TBD) under certain constraints (TBD);
-2. at some point, the _Owner_ SHOULD renounce their privileges, and the contract MUST become immutable;
-3. further upgrades, if necessary, can be done by deploying a new contract and migrating the membership set.
-
-## Parameters
-
-We make the following design choices:
-- there are `3` membership tiers: low-, mid-, and high-tier;
-- prices are quoted in `USD`;
-- payment is accepted in `DAI`;
-- the price for a given tier is linearly proportional to its rate limit.
-
-For the initial deployment, we suggest the following values.
-
-| Parameter                                                 | Symbol     | Value   | Units                                                                                | Modifiable? | Comment                        |
-| --------------------------------------------------------- | ---------- | ------- | ------------------------------------------------------------------------------------ | ----------- | ------------------------------ |
-| Epoch length                                              | `epoch`    | `10`    | minutes                                                                              | Yes         |                                |
-| Maximum total rate limit of concurrent active memberships | `R_{max}`  | TBD     | messages per `epoch`                                                                 | Yes         | Can be replaced with `N_{max}` |
-| Maximum number of concurrent active memberships           | `N_{max}`  | `10000` | units                                                                                | Yes         | Can be replaced with `R_{max}` |
-| Rate limit for low-tier                                   | `R_{low}`  | `20`    | messages per `epoch`                                                                 | TBD         |                                |
-| Rate limit for mid-tier                                   | `R_{mid}`  | `200`   | messages per `epoch`                                                                 | TBD         |                                |
-| Rate limit for high-tier                                  | `R_{high}` | `600`   | messages per `epoch`                                                                 | TBD         |                                |
-| Unit price                                                | `p_u`      | `0.01`  | `USD` per `1` message per `epoch` for the duration of one membership expiration term | Yes         |                                |
-| Membership expiration term                                | `T`        | `90`    | days                                                                                 | Yes         |                                |
-| Grace period                                              | `G`        | `30`    | days                                                                                 | Yes         |                                |
-
-### Discussion on some parameter values
-
-#### Epoch length
-
-Epoch length is a global parameter set in the smart contract.
-Rate limits are defined in terms of the maximum allowed messages per epoch.
-There is a trade-off between short and long epochs.
-
-On the one hand, longer epochs allow for short-term spikes,
-which allows for more flexibility.
-Arguably, short-term bursts followed by a period of silence is a common pattern for some use cases.
-Usage peaks are expected to average out over longer time periods,
-allowing us to reason about network utilization on a longer time scale.
-
-On the other hand, long epochs lead to more memory requirements for nodes due to the growth of the nullifier log.
-Each message contains a nullifier that proves its validity in terms of RLN.
-Within the latest epoch, each relaying node stores all nullifiers to detect users exceeding the rate limit.
-Nullifier log data needs to be stored in memory.
-Each nullifier plus metadata is `128` bytes (per message).
-This means that one user with a `1` message per second rate limit (high-tier) generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per 10-min epoch.
-This corresponds to:
-- for 1000 users: approximately `73 MiB`;
-- for 10 thousand users: approximately `732 MiB`.
-
-#### Maximum total message limit / concurrently active memberships
-
-We may want to limit the total rate limit available to all users.
-The rationale is that the total network bandwidth is a limited resource.
-The total active rate limit should not exceed the network's real capabilities.
-
-There may be two ways to implement a global cap:
-- limit the total rate limits;
-- limit the total number of active memberships (e.g., at 10K memberships).
-
-#### Proportional pricing
-
-We suggest proportional pricing for simplicity.
-Proportional pricing means that if tier A offers N times the limit of tier B, then tier A is N times more expensive than tier B.
-
-An alternative approach could be bulk discounts for high-tier memberships.
-Discounts are more efficient but promote centralization.
-Finding the right trade-off remains subject for future work.
-
-#### Accepted tokens
-
-When choosing a token to accept, we consider the following criteria:
-
-- a stablecoin: USD-denominated pricing is simpler for users and for developers (avoiding an oracle);
-- popular, high liquidity;
-- preferably decentralized;
-- with a reasonably good track record w.r.t. censorship.
-
-Based on these criteria, we suggest accepting DAI for the initial deployment.
-Other tokens may be added in the future.
-
-#### Grace period and membership extension
-
-Membership extension does not require a new deposit.
-However, the opportunity cost of locked-up capital plus gas fees for extension transactions make extensions non-free.
-Moreover, a legitimate user is unlikely to risk their membership being taken over at any moment by not renewing their membership.
-We argue that no new deposit requirement for membership extension is sufficient for the initial mainnet deployment.
 
 ## Implementation Suggestions
 
 The current version of the contract (RLNv2) is deployed on Sepolia testnet ([source code](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol)).
 
+The RECOMMENDED parameter values for the initial mainnet deployment are listed in the following table.
+All parameter values MUST be modifiable by the contract _Owner_.
+
+| Parameter                                   | Symbol    | Value   | Units                              |
+| ------------------------------------------- | --------- | ------- | ---------------------------------- |
+| Epoch length                                | `epoch`   | `10`    | minutes                            |
+| Maximum total rate limit of all memberships | `R_{max}` | `20000` | messages per `epoch`               |
+| Minimal rate limit of one membership        | `r_{min}` | `20`    | messages per `epoch`               |
+| Price of `1` message per epoch              | `p_u`     | `0.01`  | `USD` per one period of length `T` |
+| Membership expiration term                  | `T`       | `90`    | days                               |
+| Membership grace period                     | `G`       | `30`    | days                               |
+| Accepted tokens                             |           | `DAI`   |                                    |
+| Reference currency                          |           | `USD`   |                                    |
+| Pricing function                            |           | linear  |                                    |
+
+Applications MAY suggest the following rate limits to their users:
+- `20` messages per epoch as low-tier;
+- `200` messages per epoch as mid-tier;
+- `600` messages per epoch as high-tier.
+
+## Q&A
+
+### Why can't I withdraw a deposit from an _active_ membership?
+
+The rationale for this limitation is to prevent an undesirable usage pattern where users make deposits and withdrawals in short succession.
+
+### Why can't I extend an active membership?
+
+We do not allow extending an _active_ membership.
+The rationale here is that if the _Owner_ changes some contract parameters (e.g., for security purposes),
+users with extended memberships will not be affected by the changes for a long time.
+
+### What happens if I don't extend my membership during its grace period?
+
+The user who does not extend their membership during its grace period, assumes the risk of the membership being overwritten (and therefore _erased_) at any moment.
+We expect that most honest users would not want to take that risk and would either extend their memberships or withdraw their deposits during the grace period.
+
+TBD: should we make membership _erased_ immediately on deposit withdrawal?
+
+### Can I send messages after my membership expires?
+
+A membership allows sending messages for some time after expiry.
+
+Sending messages is managed by Relay nodes, not by RLN contract.
+The RLN proof that message senders provide to Relay nodes only proves whether the sender owns _some_ membership included in the RLN tree.
+The sender cannot prove the state of that membership.
+
+_Expired_ memberships are not erased from the tree proactively,
+as this would require someone to send a transaction and pay the gas costs.
+Instead, an _expired_ membership is only _erased_ when a new memberships overwrites it.
+
+### Will my deposit be slashed if I exceed the rate limit?
+
+The aim of the deposit initially is to protect the network from denial-of-service attacks with bandwidth capping.
+The current version of RLN does not involve slashing.
+
+### Do I need an extra deposit to extend a membership?
+
+Membership extension requires no additional deposit.
+The opportunity cost of locked-up capital plus gas fees for extension transactions make extensions non-free, which is sufficient for the initial mainnet deployment.
+
+### Why this particular epoch length?
+
+Epoch length is a global parameter set in the smart contract.
+Rate limits are defined in terms of the maximum allowed messages per epoch.
+There is a trade-off between short and long epochs.
+
+On the one hand, longer epochs allow for better accommodating short-term usage peaks.
+Peaks tend to average out over longer time periods,
+which allows us to reason about network utilization on a longer time scale.
+
+On the other hand, long epochs increases memory requirements for Relay nodes.
+Each message contains a nullifier that proves its validity in terms of RLN.
+Each Relay node must keeps in memory a nullifier log for the current epoch.
+
+We chose an epoch length of `10` minutes as a reasonable middle-ground.
+Each nullifier plus metadata is `128` bytes (per message).
+With a `10`-minute epoch, one high-tier user with a `1` message per second rate limit generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per epoch.
+This corresponds to:
+- for 1000 users: approximately `73 MiB`;
+- for 10 thousand users: approximately `732 MiB`.
+
+### Why is there a cap on the total rate limit?
+
+Total network bandwidth is a limited resource.
+We want to cap the total rate limit, at least in the initial mainnet deployment, to avoid overstretching the network's capabilities.
+
+### Why is there a minimal rate limit?
+
+The minimal rate limit prevents an attack where someone registers a large number of memberships with a tiny rate limit each, causing the RLN tree to contain too many elements.
+
+### Are there bulk discounts for high-rate memberships?
+
+For the initial mainnet deployment, membership price is linearly proportional to its rate limit.
+We choose this pricing scheme for simplicity.
+In other words, there are no bulk discounts.
+High-rate memberships are arguably more efficient but can incentivize centralization.
+Finding a pricing scheme with the right trade-off remains subject for future work.
+
+### Why only accept DAI?
+
+When choosing a token to accept, we considered the following criteria:
+- a stablecoin, as USD-denominated pricing is familiar for users and requires no oracle;
+- popular, high liquidity;
+- preferably decentralized;
+- with a reasonably good track record w.r.t. censorship.
+
+Based on these criteria, we chose DAI for the initial mainnet deployment.
+Other tokens may be added in the future.
+
 ## Security / Privacy Considerations
 
-Requesting a Merkle proof for one's own membership through a third-party RPC provider may endanger the requester's privacy.
+Issuing membership-specific transactions (e.g., membership extension and deposit withdrawal) publicly links it to an Ethereum address.
+Note that this does not degrade the privacy of the relayed messages.
+
+To produce an RLN proof, a message sender must obtain a Merkle proof for their RLN membership.
+One way to obtain this proof is to request it from the RLN smart contract.
+Requesting a proof through a third-party RPC provider may endanger the sender's privacy.
+The provider would be able to link the requester's Ethereum address and the RLN membership with the corresponding API key.
 
 ## Copyright
 
@@ -282,6 +269,14 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 
 ## References
 
+- [Rate-Limiting Nullifier](https://rate-limiting-nullifier.github.io/rln-docs/)
 - [11/WAKU2-RELAY](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/11/relay.md)
 - [17/WAKU2-RLN-RELAY](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/17/rln-relay.md)
+
+
+
+---
+
+
+
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -46,15 +46,15 @@ The contract MUST provide the following functionalities:
 
 Contract parameters and their RECOMMENDED values for the initial mainnet deployment are as follows:
 
-| Parameter                                   | Symbol    | Value   | Units                |
-| ------------------------------------------- | --------- | ------- | -------------------- |
-| Epoch length                                | `epoch`   | `10`    | minutes              |
-| Maximum total rate limit of all memberships | `R_{max}` | `20000` | messages per `epoch` |
-| Minimal rate limit of one membership        | `r_{min}` | `20`    | messages per `epoch` |
-| Membership price for `1` message per epoch  | `p_u`     | `0.05`  | `USD`                |
-| Membership expiration term                  | `T`       | `180`   | days                 |
-| Membership grace period                     | `G`       | `30`    | days                 |
-| Accepted tokens                             |           | `DAI`   |                      |
+| Parameter                                   | Symbol    | Value    | Units                |
+| ------------------------------------------- | --------- | -------- | -------------------- |
+| Epoch length                                | `epoch`   | `10`     | minutes              |
+| Maximum total rate limit of all memberships | `R_{max}` | `160000` | messages per `epoch` |
+| Minimal rate limit of one membership        | `r_{min}` | `20`     | messages per `epoch` |
+| Membership price for `1` message per epoch  | `p_u`     | `0.05`   | `USD`                |
+| Membership expiration term                  | `T`       | `180`    | days                 |
+| Membership grace period                     | `G`       | `30`     | days                 |
+| Accepted tokens                             |           | `DAI`    |                      |
 
 The pricing function SHOULD be linear in the rate limit per epoch.
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -34,7 +34,7 @@ and to get the necessary data for proof generation and verification.
 
 Sending messages is handled by Waku RLN Relay nodes.
 To send a message, the sender MUST prove its validity in terms of RLN.
-An RLN Relay node MUST relay a message unless it is invalid.
+RLN Relay nodes MUST NOT relay invalid messages.
 See [17/WAKU2-RLN-RELAY](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/17/rln-relay.md) for the full specification of RLN Relay.
 
 ## Contract overview

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -89,8 +89,8 @@ There is no limitation on the number of membership per user (apart from the glob
 
 The contract governance is as follows:
 
-1. the first deployment of the contract allows the `Owner` to modify certain parameters (TBD) under certain constraints (TBD);
-2. at some point, the `Onwer` would renounce their privileges, and the contract will become immutable;
+1. the first deployment of the contract allows the _Owner_ to modify certain parameters (TBD) under certain constraints (TBD);
+2. at some point, the _Owner_ SHOULD renounce their privileges, and the contract MUST become immutable;
 3. further upgrades, if necessary, can be done by deploying a new contract and migrating the membership set.
 
 ## Parameters

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -51,7 +51,7 @@ Contract parameters and their RECOMMENDED values for the initial mainnet deploym
 | Epoch length                                | `epoch`   | `10`    | minutes              |
 | Maximum total rate limit of all memberships | `R_{max}` | `20000` | messages per `epoch` |
 | Minimal rate limit of one membership        | `r_{min}` | `20`    | messages per `epoch` |
-| Membership price for `1` message per epoch  | `p_u`     | `0.01`  | `USD`                |
+| Membership price for `1` message per epoch  | `p_u`     | `0.05`  | `USD`                |
 | Membership expiration term                  | `T`       | `180`   | days                 |
 | Membership grace period                     | `G`       | `30`    | days                 |
 | Accepted tokens                             |           | `DAI`   |                      |
@@ -197,7 +197,7 @@ users with extended memberships will not be affected by the changes for a long t
 ### What if I don't extend my membership within its _GracePeriod_?
 
 The user who does not extend their _GracePeriod_ membership, 
-assume the risk of the membership being overwritten at any moment.
+assume the risk of their _Expired_ membership being overwritten.
 We expect, generally, that a user would not want to take that risk 
 and would either extend their membership or withdraw their deposit.
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -111,6 +111,7 @@ Availability of membership-specific functionalities MUST be as follows:
 | Send a message        | Yes    | Yes         | Yes     | No                     | No     |
 | Extend the membership | No     | Yes         | No      | No                     | No     |
 | Withdraw the deposit  | No     | Yes         | Yes     | Yes                    | No     |
+
 Sending a message is included here for completeness,
 although it is part of the Relay protocol and not the RLN contract.
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -44,6 +44,11 @@ The contract MUST provide the following functionalities:
 - extend a membership;
 - withdraw a deposit.
 
+A membership _holder_ is the entity that controls the secret of the respective RLN commitment.
+A membership _keeper_ is the entity that controls the Ethereum address that registered that membership.
+The holder and the keeper MAY differ for the same membership.
+The contract SHOULD only distinguish between the keeper and non-keepers when authorizing membership-related requests.
+
 Contract parameters and their RECOMMENDED values for the initial mainnet deployment are as follows:
 
 | Parameter                                   | Symbol    | Value    | Units                |
@@ -126,7 +131,7 @@ Membership registration is subject to the following conditions:
 - if a new membership A overwrites an _Expired_ membership B:
 	- membership B MUST become _ErasedAwaitsWithdrawal_;
 	- the current total rate limit MUST be decremented by the rate limit of membership B;
-	- the contract MUST take all necessary steps to ensure that the holder of membership B can withdraw their deposit later;
+	- the contract MUST take all necessary steps to ensure that the keeper of membership B can withdraw their deposit later;
 - registration MUST fail if the total rate limit of _Active_, _GracePeriod_, and _Expired_ memberships, including the one being created, would exceed the maximum total rate;
 - registration MUST fail if the requested rate limit for a new membership is lower than the minimal allowed rate limit;
 - the user MUST lock-up a deposit to register a membership;
@@ -143,17 +148,17 @@ Membership registration is subject to the following conditions:
 
 Extending a membership is subject to the following conditions:
 - extension MUST fail if the membership is in any state other than _GracePeriod_;
-- the membership holder MUST be able to extend their membership;
-- any user except the membership holder MUST NOT be able to extend a membership;
+- the membership keeper MUST be able to extend their membership;
+- any user except the membership keeper MUST NOT be able to extend a membership;
 - after a successful extension, the membership MUST become _Active_.
 
-Holding a membership means controlling the private key from which the RLN commitment ID (i.e., public key) was derived.
+
 
 ### Withdraw the deposit
 
 Deposit withdrawal is subject to the following conditions:
-- the membership holder MUST be able to withdraw their deposit;
-- any user except the membership holder MUST NOT be able to withdraw its deposit;
+- the membership keeper MUST be able to withdraw their deposit;
+- any user except the membership keeper MUST NOT be able to withdraw its deposit;
 - a deposit MUST be withdrawn in full;
 - a withdrawal MUST fail if the membership is not in _GracePeriod_, _Expired_, or _ErasedAwaitsWithdrawal_;
 - a membership MUST become _Erased_ after withdrawal.
@@ -233,7 +238,7 @@ On the one hand, longer epochs allow for better accommodating short-term usage p
 On the other hand, long epochs increases memory requirements for RLN Relay nodes.
 
 Each message contains a nullifier that proves its validity in terms of RLN.
-Each RLN Relay node must keep in memory a nullifier log for the current epoch.
+Each RLN Relay node must store in memory a nullifier log for the current epoch.
 Each nullifier plus metadata is `128` bytes (per message).
 With a `10`-minute epoch, one high-tier user with a `1` message per second rate limit generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per epoch.
 This corresponds to:

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -40,19 +40,21 @@ It may also be explored as a revenue stream for Waku in later versions.
 
 ## Semantics
 
+This section is not intended to describe the full contract functionality.
+We only focus on functions required for managing memberships, expiration, deposits, etc.
+The document might later evolve into a full-fledged contract specification.
+
 The RLN contract provides the following functionalities:
 - register a membership in a given tier;
-- check if a membership is valid;
-- withdraw the deposit for an expired membership;
-- get a merkle proof
-- get the merkle tree (root?)
+- extend a membership;
+- withdraw the deposit for an expired membership.
 
 For the _Contract Owner_, the contract provides the following additional functionality:
 - change the modifiable parameters (see parameter table below);
 - (TBD) freeze certain functionality (e.g., in case of an attack, stop new registrations, deposit withdrawals, etc).
 
 In the initial deployment:
-- there is no slashing;
+- there is no slashing - that is, a user's deposit is not taken away in case of misbehavior;
 - membership expiration includes a grace period;
 - a user can extend their membership without putting up any additional deposit.
 
@@ -70,9 +72,9 @@ In more detail, the membership life-cycle is as follows:
     1. If there are expired unclaimed slots in the tree, use the slot with the earliest expiration date past its grace period, otherwise create a new slot;
     2. if the membership re-uses a previously used slot, the previous user can claim their deposit back.
 2. The user sends messages while the membership is active:
-    1. If the user exceeds the rate limit, their over-limit messages are not propagated in that epoch; the deposit is not slashed.
+    1. If the user exceeds the rate limit, their over-limit messages are not propagated; the deposit is not slashed.
 3. After the membership expires, the user can do one of the following:
-    1. Do nothing. The deposit remains in the contract, and the user retains the ability to send messages (respecting the per-epoch rate limit); until another user takes their slot
+    1. Do nothing. The deposit remains in the contract, and the user retains the ability to send messages (respecting the per-epoch rate limit) until another user takes their slot;
     2. Withdraw the deposit. The user receives the full deposit back, and loses the ability to send messages;
     3. Extend the membership. The user sends a transaction to re-enable their membership for another expiration term. The user only covers gas costs and does not have to provide additional funds. The original deposit remains in the contract. The membership is prolonged for another expiration term under the same conditions.
 
@@ -185,18 +187,6 @@ The current version of the contract (RLNv2) is deployed on Sepolia testnet ([sou
 ## Security / Privacy Considerations
 
 Requesting a Merkle proof for one's own membership through a third-party RPC provider may endanger the requester's privacy.
-
-## Future work
-
-In the future version of RLN contract, the following research directions might be pursued:
-- deposit slashing for misbehaving users;
-- extracting revenue by e.g. only allowing partial deposit withdrawal;
-- incentivization for relaying nodes;
-- non-proportional pricing (e.g., high-tier discounts);
-- accepting other tokens;
-- making memberships transferable (e.g., in the form of an NFT);
-- establishing a free relaying market by economically linking demand with supply;
-- countering potential centralization of membership ownership.
 
 ## Copyright
 

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -239,7 +239,7 @@ On the one hand, longer epochs allow for better accommodating short-term usage p
 On the other hand, long epochs increases memory requirements for Relay nodes.
 
 Each message contains a nullifier that proves its validity in terms of RLN.
-Each Relay node must keeps in memory a nullifier log for the current epoch.
+Each Relay node must keep in memory a nullifier log for the current epoch.
 Each nullifier plus metadata is `128` bytes (per message).
 With a `10`-minute epoch, one high-tier user with a `1` message per second rate limit generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per epoch.
 This corresponds to:

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -20,6 +20,10 @@ It might later evolve into a full-fledged contract specification.
 RLN is only deployed on Sepolia testnet ([source code](https://github.com/waku-org/waku-rlnv2-contract/blob/main/src/WakuRlnV2.sol)) as of August 2024.
 This document aims to outline the path to its mainnet deployment.
 
+## Syntax
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
 ## Background
 
 Rate-Limiting Nullifier (RLN) is a ZK-based gadget used for privacy-preserving rate limiting in Waku.
@@ -28,14 +32,10 @@ The smart contract stores the RLN tree that contains all currently existing memb
 Users interact with the contract to manage their memberships
 and to get the necessary data for proof generation and verification.
 
-Sending messages is handled by Waku Relay nodes.
-To send a message, the sender MUST attach a ZK-proof to the message.
-A Relay node MUST relay a message unless:
-- the message belongs to any epoch other than the current one; or
-- the user has exceed their allowed rate limit for the current epoch; or
-- the ZK-proof fails to prove that the sender holds a membership.
-
-The full specification of Relay is out of scope for this document.
+Sending messages is handled by Waku RLN Relay nodes.
+To send a message, the sender MUST prove its validity in terms of RLN.
+An RLN Relay node MUST relay a message unless it is invalid.
+See [17/WAKU2-RLN-RELAY](https://github.com/vacp2p/rfc-index/blob/main/waku/standards/core/17/rln-relay.md) for the full specification of RLN Relay.
 
 ## Contract overview
 
@@ -113,7 +113,7 @@ Availability of membership-specific functionalities MUST be as follows:
 | Withdraw the deposit  | No     | Yes         | Yes     | Yes                    | No     |
 
 Sending a message is included here for completeness,
-although it is part of the Relay protocol and not the RLN contract.
+although it is part of the RLN Relay protocol and not the RLN contract.
 
 ### Register a membership
 
@@ -210,8 +210,8 @@ and would either extend their memberships or withdraw their deposits.
 ### Can I send messages when my membership is _Expired_?
 
 An _Expired_ membership allows sending messages for some time.
-Sending messages is managed by Relay nodes.
-The RLN proof that message senders provide to Relay nodes doesn't prove the state of that membership.
+Sending messages is managed by RLN Relay nodes.
+The RLN proof that message senders provide to RLN Relay nodes doesn't prove the state of that membership.
 
 _Expired_ memberships are not erased from the tree proactively.
 An _Expired_ membership is only erased when either a new membership overwrites it,
@@ -236,10 +236,10 @@ There is a trade-off between short and long epochs.
 We chose an epoch length of `10` minutes as a reasonable middle-ground.
 
 On the one hand, longer epochs allow for better accommodating short-term usage peaks.
-On the other hand, long epochs increases memory requirements for Relay nodes.
+On the other hand, long epochs increases memory requirements for RLN Relay nodes.
 
 Each message contains a nullifier that proves its validity in terms of RLN.
-Each Relay node must keep in memory a nullifier log for the current epoch.
+Each RLN Relay node must keep in memory a nullifier log for the current epoch.
 Each nullifier plus metadata is `128` bytes (per message).
 With a `10`-minute epoch, one high-tier user with a `1` message per second rate limit generates up to `600 * 128 / 1024 = 75 KiB` of nullifier log data per epoch.
 This corresponds to:

--- a/standards/core/rln-contract.md
+++ b/standards/core/rln-contract.md
@@ -114,7 +114,7 @@ Membership registration is subject to the following conditions:
 - if an _Expired_ membership A is overwritten by membership B:
 	- membership B MUST transition to _ErasedAwaitsWithdrawal_;
 	- the current total rate limit MUST be decremented by the rate limit of membership B;
-	- the contract MUST take all necessary steps to ensure that the owner of membership B can withdraw their deposit later;
+	- the contract MUST take all necessary steps to ensure that the holder of membership B can withdraw their deposit later;
 - registration MUST fail if the total rate limit of _Active_, _GracePeriod_, and _Expired_ memberships, including the one being created, would exceed the limit;
 - registration MUST fail if the requested rate limit for the new membership is lower than the minimal allowed rate limit;
 - the user MUST lock-up a deposit to register a membership;
@@ -140,8 +140,8 @@ A Relay node MUST relay a message unless:
 
 Extending a membership is subject to the following condition:
 - extension MUST fail if the membership is in any state other than _GracePeriod_;
-- the membership owner MUST be able to extend the membership;
-- any user except the membership owner MUST NOT be able to extend the membership;
+- the membership holder MUST be able to extend their membership;
+- any user except the membership holder MUST NOT be able to extend a membership;
 - after a successful extension, the membership MUST become _Active_.
 
 Owning a membership means controlling the private key from which the RLN commitment ID (i.e., public key) was derived.
@@ -149,8 +149,8 @@ Owning a membership means controlling the private key from which the RLN commitm
 ### Withdraw the deposit
 
 Deposit withdrawal is subject to the following conditions:
-- the owner of a membership MUST be able to withdraw their deposit;
-- any user except the membership owner MUST NOT be able to withdraw its deposit;
+- the membership holder MUST be able to withdraw their deposit;
+- any user except the membership holder MUST NOT be able to withdraw its deposit;
 - a deposit MUST be withdrawn in full;
 - a withdrawal MUST fail if the membership is not in _GracePeriod_, _Expired_, or _ErasedAwaitsWithdrawal_;
 - any withdrawal MUST move the membership to _Erased_.


### PR DESCRIPTION
This PR adds the first version of the specification for the RLN contract for mainnet deployment.

Added functionality is mainly related to membership tiers, pricing, expiration, and deposits.

This is work in progress, certain aspects are TBD for now. Comments and suggestions welcome!

See also: a less formal [Notion document](https://www.notion.so/Minimal-specification-for-RLN-on-mainnet-fba4417b0eb84bf887969a78f7f625d5?d=1ad0907b813f439a9952d35a44c71bb0) (not open-access) that preceded this spec.