### PR TITLE
Chat Content Frames

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -29,6 +29,7 @@ closeChannel
 config
 ConnectionStatus
 ConnectionStatusEvent
+ContentFrame
 contentTopic
 contentTopics
 createNode
@@ -131,6 +132,7 @@ MessageSentEvent
 MessageValidation
 MiB
 multiaddr
+namespace
 NetworkConfig
 NetworkingConfig
 nim
@@ -151,11 +153,13 @@ PascalCase
 Pax
 plaintext
 PoV
+permissionless
 pluggable
 Prathi
 pre
 Prem
 ProtocolsConfig
+protobuf
 pubsub
 rateLimitConfig
 Req

--- a/standards/application/contentframe.md
+++ b/standards/application/contentframe.md
@@ -1,0 +1,100 @@
+---
+title: CONTENTFRAME
+name: 
+category: Standards Track
+tags: 
+editor: Jazzz
+contributors:
+---
+
+## Abstract
+
+
+## Background / Rationale / Motivation
+
+
+
+## Theory / Semantics
+
+### Definitions
+
+- **Type:** A data structure used to store data
+- **ContentType:** A `type` used specifically encode data intended for applications
+
+### ContentFrame
+
+A ContentFrame is used to distinguish the application level content, from payloads intended to modify protocol state -- while also providing the necessary context to properly decode it.
+
+This specification provide:
+- a structured approach to enable inter-operation of content types between applications.
+- Flexible mechanism that allows permissionless type definition by all developers.
+
+
+### Domain
+
+A domain defines the authority which governs a set of content types. It cannot be assumed that all specifications covering content types reside in the same location or are governed by the same entity. By including the `domain` receiving application developers can determine where the definition of the type resides, regardless of where it originated.
+
+- a domain MUST be a valid url.
+- a domain SHOULD provide specifications for all of its defined types.
+
+To reduce payload size, Domains are mapped to an integer `domain_id`. The mappings can be found [here](#appendix-a-domains)
+
+- a domain_id MUST be an integer value in the range [0, 65,535]
+- a domain_id MUST correspond to a single unique domain
+
+### Tag
+
+A tag uniquely defines a type within a domain. Domains 
+
+- a tag MUST correspond to a single unique type within a domain
+
+Each domain is responsible for managing its tags and providing documentation to developers on how the corresponding types are used.
+
+
+## Wire Format Specification / Syntax
+
+```protobuf
+message ContentFrame {
+    uint32 domain_id = 1;
+    uint32 tag = 2;
+    bytes bytes = 3;
+}
+```
+
+**domain_id:** This field contains an integer which identifies the domain of this type.
+**tag:** This field contains an integer which identifies which type `bytes` contains
+**bytes:** This field contains the encoded payload 
+
+
+
+## Implementation Suggestions (optional)
+
+### Tags -> Specifications
+
+If possible the integer tag values should be the same as the specification which defines the type used. While not necessary, using the specification id directly removes the requirement to maintain a separate mapping of tag -> specification. 
+
+### Fragmentation
+
+This protocol allows for multiple competing definitions of similar content types. Having multiple definitions of a `TextMessage` or `Image` will increase fragmentation between applications. Where possible reusing existing types will reduce burden on app developers, and increase interoperability between apps.
+
+Domains should focus on providing types unique to their service or usecase.
+
+
+## Security/Privacy Considerations
+
+
+
+
+# Appendix A: Domains
+**TODO:** 
+- Find appropriate home for this.
+
+Domain ID's are provided on a first come first serve basis.
+
+
+- A domain MUST only appear once in the table
+- 
+
+| domain_id |  specification repository |
+|-----------|-------------------------------------|
+| 0         |   https://github.com/waku-org/specs |   

--- a/standards/application/contentframe.md
+++ b/standards/application/contentframe.md
@@ -12,23 +12,29 @@ contributors:
 
 ## Background / Rationale / Motivation
 
+Application developers use chat protocols to send payloads between clients. However not all payloads sent over a protocol are intended to be read by the end users. In normal operation a chat protocol needs to notify the chat clients of event changes in order to keep all clients synchronized. With a finite set of message types, its possible to explicitly label each type as "content" or "meta-message" and route the payload appropriately. In an evolving decentralized chat protocol, this is not alway possible. When a client receives a payload it does not understand, there exists an ambiguity of whether this message contains a payload intended for the application, or a protocol message type which it does not understand. This ambiguity makes versioning between clients difficult. 
 
+Furthermore as applications communicating with each other cannot be guaranteed to be compatible, its possible that applications can also receive messages and be uncertain as how to parse incoming messages.
+
+Having a mechanism that removes the ambiguity of how to handle payloads intended for end users is beneficial for both clients and applications.
 
 ## Theory / Semantics
 
 ### Definitions
 
-- **Type:** A data structure used to store data
-- **ContentType:** A `type` used specifically encode data intended for applications
+This document makes use of the shared terminology defined in the [CHATDEFS]() protocol.
+
+[Payload, Application, client]
 
 ### ContentFrame
 
-A ContentFrame is used to distinguish the application level content, from payloads intended to modify protocol state -- while also providing the necessary context to properly decode it.
+A ContentFrame is used to describe messages intended to be consumed by applications/end users. 
 
-This specification provide:
-- a structured approach to enable inter-operation of content types between applications.
-- Flexible mechanism that allows permissionless type definition by all developers.
+The presence of a ContentFrame removes ambiguity of who the handler of a given payload is, and its fields describe how to parse the attached payload. This decouples of the encoded data from the software that created it increasing protocol resilience.
 
+ContentFrames make no assumptions of the data contained, and defer to 
+
+- All payloads intended to be consumed by the application MUST be wrapped in a ContentFrame.
 
 ### Domain
 
@@ -39,16 +45,15 @@ A domain defines the authority which governs a set of content types. It cannot b
 
 To reduce payload size, Domains are mapped to an integer `domain_id`. The mappings can be found [here](#appendix-a-domains)
 
-- a domain_id MUST be an integer value in the range [0, 65,535]
+- a domain_id MUST be a positive integer value
 - a domain_id MUST correspond to a single unique domain
 
 ### Tag
 
-A tag uniquely defines a type within a domain. Domains 
-
+A tag uniquely defines a type within a domain. After parsing the Domain and the tag application developers have all the data required to process the payload. Each domain is responsible for managing its tags and providing documentation to developers on how the corresponding types are used.
+ 
 - a tag MUST correspond to a single unique type within a domain
-
-Each domain is responsible for managing its tags and providing documentation to developers on how the corresponding types are used.
+- payloads with the same tag MUST be formatted the same
 
 
 ## Wire Format Specification / Syntax
@@ -79,10 +84,14 @@ This protocol allows for multiple competing definitions of similar content types
 
 Domains should focus on providing types unique to their service or usecase.
 
+### Tag Selection
+
+New types SHOULD be allocated the next available tag within a domain. Choosing larger values will needlessly increase payload size.
+
 
 ## Security/Privacy Considerations
 
-
+The privacy and security properties are inherited by the protocol used to transmit these payloads.
 
 
 # Appendix A: Domains
@@ -93,7 +102,6 @@ Domain ID's are provided on a first come first serve basis.
 
 
 - A domain MUST only appear once in the table
-- 
 
 | domain_id |  specification repository |
 |-----------|-------------------------------------|

--- a/standards/application/contentframe.md
+++ b/standards/application/contentframe.md
@@ -9,35 +9,41 @@ contributors:
 
 ## Abstract
 
-This specification defines ContentFrame, a self-describing message format for decentralized chat networks. ContentFrame wraps content payloads with metadata identifying their type and governing specification repository. Using a `(domain, tag)` tuple, applications can uniquely identify message types and locate authoritative documentation for parsing unfamiliar content. This approach enables permissionless innovation while maintaining the context needed for interoperability, allowing applications to gracefully handle messages from sources they don't explicitly know about.
+This specification defines ContentFrame, a self-describing message format for decentralized chat networks.
+ContentFrame wraps content payloads with metadata identifying their type and governing specification repository.
+Using a `(domain, tag)` tuple, applications can uniquely identify message types and locate authoritative documentation for parsing unfamiliar content.
+This approach enables permissionless innovation while maintaining the context needed for interoperability, allowing applications to gracefully handle messages from sources they don't explicitly know about.
 
 ## Motivation
 
-In an interoperable chat network, participants cannot be assumed to use the same software to send and receive messages. Users may employ different versions of the same application or different applications entirely. This heterogeneity creates a fundamental challenge: how can applications support extensible message types without prior knowledge of every possible format?
+In an interoperable chat network, participants cannot be assumed to use the same software to send and receive messages.
+Users may employ different versions of the same application or different applications entirely.
+This heterogeneity creates a fundamental challenge: how can applications support extensible message types without prior knowledge of every possible format?
 
 Two naive approaches each have significant drawbacks:
 
-**Developer-defined types** would allow flexibility but create fragmentation. When developers define their own message types, the context for parsing these messages remains tightly coupled to the software that created them. Other applications receiving these messages lack the necessary context to interpret them correctly. This leads to multiple definitions of basic types such as `Text` and `Image` that are not compatible across applications.
+**Developer-defined types** would allow flexibility but create fragmentation.
+When developers define their own message types, the context for parsing these messages remains tightly coupled to the software that created them.
+Other applications receiving these messages lack the necessary context to interpret them correctly.
+This leads to multiple definitions of basic types such as `Text` and `Image` that are not compatible across applications.
 
-**Fixed type systems** would ensure universal understanding but restrict innovation. A predetermined set of message types eliminates ambiguity but adds friction for developers who want to extend functionality. In a permissionless, decentralized protocol, requiring centralized approval for new message types contradicts core design principles.
+**Fixed type systems** would ensure universal understanding but restrict innovation.
+A predetermined set of message types eliminates ambiguity but adds friction for developers who want to extend functionality.
+In a permissionless, decentralized protocol, requiring centralized approval for new message types contradicts core design principles.
 
 The core challenge is managing fragmentation in a decentralized protocol while preserving developer freedom to innovate.
 
-**Solution:** A self-describing message format that encodes both the payload and the metadata needed to parse it. This approach directs application developers on how a message should be parsed while providing a clear path to learn about unfamiliar content types they encounter. By decoupling the encoded data from the specific software that created it, applications can gracefully handle messages from diverse sources without sacrificing extensibility.
+**Solution:** A self-describing message format that encodes both the payload and the metadata needed to parse it.
+This approach directs application developers on how a message should be parsed while providing a clear path to learn about unfamiliar content types they encounter.
+By decoupling the encoded data from the specific software that created it, applications can gracefully handle messages from diverse sources without sacrificing extensibility.
 
 
 ## Theory / Semantics
 
-### Definitions
-
-This document makes use of the shared terminology defined in the [CHATDEFS]() protocol.
-
-[Payload, Application, client]
-
-
 ### ContentFrame
 
-A ContentFrame provides a self-describing format for payload types by encoding both the type identifier and its administrative origin. The core principle is that each payload should declare which entity is responsible for its definition and provide a unique type discriminator within that entity's namespace.
+A ContentFrame provides a self-describing format for payload types by encoding both the type identifier and its administrative origin.
+The core principle is that each payload should declare which entity is responsible for its definition and provide a unique type discriminator within that entity's namespace.
 
 A ContentFrame consists of two key components:
 
@@ -73,7 +79,8 @@ flowchart TD
 
 ### Domain
 
-A domain identifies the authority responsible for defining and governing a set of content types. By including the domain, receiving applications can locate the authoritative specification for a type, regardless of which application originally sent it.
+A domain identifies the authority responsible for defining and governing a set of content types.
+By including the domain, receiving applications can locate the authoritative specification for a type, regardless of which application originally sent it.
 
 **Requirements:**
 
@@ -83,12 +90,14 @@ A domain identifies the authority responsible for defining and governing a set o
 
 **Specification Format:**
 
-Domains are responsible for describing their types in whatever format is most appropriate. The only requirement is that the information needed to parse and understand each type is accessible from the domain URL.
+Domains are responsible for describing their types in whatever format is most appropriate.
+The only requirement is that the information needed to parse and understand each type is accessible from the domain URL.
 
 
 **Domain ID Mapping:**
 
-To minimize payload size, domains are mapped to integer identifiers. Each domain is assigned a unique `domain_id` which is used in the wire format instead of the full URL.
+To minimize payload size, domains are mapped to integer identifiers.
+Each domain is assigned a unique `domain_id` which is used in the wire format instead of the full URL.
 
 - A `domain_id` MUST be a positive integer value
 - A `domain_id` MUST correspond to exactly one unique domain
@@ -96,7 +105,8 @@ To minimize payload size, domains are mapped to integer identifiers. Each domain
 
 ### Tag
 
-A tag is a numeric identifier that uniquely specifies a content type within a domain's namespace. After resolving the domain and tag, application developers have all the information needed to locate the definition and parse the payload.
+A tag is a numeric identifier that uniquely specifies a content type within a domain's namespace.
+After resolving the domain and tag, application developers have all the information needed to locate the definition and parse the payload.
 
 **Requirements:**
 
@@ -138,11 +148,14 @@ All fields are required.
 
 ### Tags to Specifications
 
-Where possible, tag values should directly correspond to specification identifiers. Using specification IDs as tags removes the need to maintain a separate mapping between tags and specifications.
+Where possible, tag values should directly correspond to specification identifiers.
+Using specification IDs as tags removes the need to maintain a separate mapping between tags and specifications.
 
 ### Fragmentation
 
-This protocol allows multiple competing definitions of similar content types. Having multiple definitions of `Text` or `Image` increases fragmentation between applications. Where possible, reusing existing types will reduce burden on developers and increase interoperability.
+This protocol allows multiple competing definitions of similar content types.
+Having multiple definitions of `Text` or `Image` increases fragmentation between applications.
+Where possible, reusing existing types will reduce burden on developers and increase interoperability.
 
 Domains should focus on providing types unique to their service or use case.
 
@@ -151,7 +164,8 @@ Domains should focus on providing types unique to their service or use case.
 
 ![TODO] Find appropriate home for this registry.
 
-Domain IDs are assigned sequentially on a first-come, first-served basis. New domains are added via pull request.
+Domain IDs are assigned sequentially on a first-come, first-served basis.
+New domains are added via pull request.
 
 **Registry Rules:**
 

--- a/standards/application/contentframe.md
+++ b/standards/application/contentframe.md
@@ -176,4 +176,4 @@ New domains are added via pull request.
 
 | domain_id | specification repository             |
 |-----------|--------------------------------------|
-| 0         | https://github.com/waku-org/specs    |
+| 1         | https://github.com/waku-org/specs    |


### PR DESCRIPTION
This PR adds a specification which describes a method for self-describing content types. 

It aims to provide interoperability between client versions while enabling developers to create types permissionlessly. 